### PR TITLE
Reset 'Play' button and self.playing state after the audio is finished playing

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -76,6 +76,9 @@ class GUI:
         while output != b'' and self.playing:
             out_stream.write(output)
             output = audio_file.readframes(self.CHUNK)
+        self.playing = False
+        self.playButton['text'] = 'Play'
+        print('audio ended')
 
     def pause(self):
         self.playing = False
@@ -309,7 +312,7 @@ class GUI:
         exportDocument = Document()
         text = self.conventionBox.get("1.0", "end")
         exportDocument.add_paragraph(text)
-        exportDocument.save(outputPath + '/' + str(date.today())+'_SALT_Transcription.docx')
+        exportDocument.save(outputPath + '/' + str(date.today())+'_SALT_Transcription.docx')      
 
 
     def __init__(self):


### PR DESCRIPTION
I added code so that after the audio is done playing, the "Play" button will change back to "Play" instead of remaining "Stop." Before this change, you would still have to click "Stop" to set the button back to "Play" and then click "Play" again to use the feature, but now it automatically resets after the audio is finished playing. fixes #73 

Explanation for changes made:
I set self.playing equal to False after the while loop that played the audio ends, as the audio is not playing anymore so the button should no longer be active in the 'Play' state.
I set the button text back to 'Play' so that the user now knows that the program is no longer in the 'Play' state as self.playing is now set to False so if the user hits the button the audio will now begin to play.
I print 'audio ended' to the terminal to keep track of the program state as that provides valuable feedback to the user for debugging or general purposes.