### PR TITLE
Fixes #47

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -224,7 +224,8 @@ class GUI:
         self.correctionEntryBox.delete('1.0', "end")
         self.submitCorrectionButton.grid(row=6, column=6)
         # Get raw transcription and tokenize into sentences for processing
-        text = self.transcriptionBox.get("1.0", "end")
+        text = self.transcriptionBox.get("1.0", "end") 
+        # perhaps above and below is the state he was talking about, but it already gets assigned to a variable called 'text'
         self.tokenizedSentences = nltk.sent_tokenize(text)
         self.getNextCorrection()
     
@@ -266,7 +267,7 @@ class GUI:
             self.transcriptionBox.grid_remove()
         else:
             self.transcriptionBox.grid(row=5, column=1, columnspan=3, padx=10, pady=10)
-        self.transcriptionIsVisible = not self.transcriptionIsVisible
+        self.transcriptionIsVisible = not self.transcriptionIsVisible 
 
     def editTranscriptionBox(self):
         if self.editTranscriptionBoxButton['text'] == 'Lock':
@@ -278,9 +279,9 @@ class GUI:
             self.transcriptionBox.configure(state='normal')
 
     def editConventionBox(self):
-        if self.editConventionBoxButton['text'] == 'Lock':
+        if self.editConventionBoxButton['text'] == 'Lock': 
             self.editConventionBoxButton['text'] = 'Unlock'
-            self.conventionBox.configure(state='disabled')
+            self.conventionBox.configure(state='disabled') 
 
         else:
             self.editConventionBoxButton['text'] = 'Lock'
@@ -307,8 +308,7 @@ class GUI:
     def exportToWord(self):
         outputPath = filedialog.askdirectory()
         exportDocument = Document()
-        #text = self.conventionBox.get("1.0", "end")
-        text = self.transcriptionBox.get("1.0", "end")
+        text = self.transcriptionBox.get("1.0", "end") # changed from conventionBox.get since that was the wrong call
         exportDocument.add_paragraph(text)
         exportDocument.save(outputPath + '/' + str(date.today())+'_SALT_Transcription.docx')
 

--- a/GUI.py
+++ b/GUI.py
@@ -198,6 +198,7 @@ class GUI:
         #normal_wav.close()
         self.transcriptionBox.configure(state='normal')
         self.transcriptionBox.insert("end", transcribedAudio + "\n")
+        self.transcriptionText = transcribedAudio
         self.transcriptionBox.configure(state='disabled')
 
     # Adds conventions to text from transcription box and puts output in conventionBox box
@@ -271,12 +272,15 @@ class GUI:
 
     def editTranscriptionBox(self):
         if self.editTranscriptionBoxButton['text'] == 'Lock':
+            self.transcriptionText = self.transcriptionBox.get("1.0", "end")
             self.editTranscriptionBoxButton['text'] = 'Unlock'
             self.transcriptionBox.configure(state='disabled')
 
         else:
             self.editTranscriptionBoxButton['text'] = 'Lock'
             self.transcriptionBox.configure(state='normal')
+
+
 
     def editConventionBox(self):
         if self.editConventionBoxButton['text'] == 'Lock': 
@@ -308,7 +312,7 @@ class GUI:
     def exportToWord(self):
         outputPath = filedialog.askdirectory()
         exportDocument = Document()
-        text = self.transcriptionBox.get("1.0", "end") # changed from conventionBox.get since that was the wrong call
+        text = self.transcriptionText
         exportDocument.add_paragraph(text)
         exportDocument.save(outputPath + '/' + str(date.today())+'_SALT_Transcription.docx')
 
@@ -343,6 +347,7 @@ class GUI:
         self.examinerName = ''
         self.samplingContext = ''
         self.infoArray = ['','','','','','','']
+        self.transcriptionText = ''
 
 
         uploadButton = Button(self.master, text='Upload', command=lambda: self.uploadAudio())

--- a/GUI.py
+++ b/GUI.py
@@ -225,7 +225,7 @@ class GUI:
         self.correctionEntryBox.delete('1.0', "end")
         self.submitCorrectionButton.grid(row=6, column=6)
         # Get raw transcription and tokenize into sentences for processing
-        text = self.transcriptionBox.get("1.0", "end") 
+        text = self.transcriptionText 
         # perhaps above and below is the state he was talking about, but it already gets assigned to a variable called 'text'
         self.tokenizedSentences = nltk.sent_tokenize(text)
         self.getNextCorrection()


### PR DESCRIPTION
… it wrong.
The original issue says to assign variables to the transcription instead of getting it from the table every time (it is very vague), however, it seems like that is already done. The original transcription is assigned to transcribedAudio in the transcribe() function and put into the transcription box. Then, any other times that the transcribed audio needs to be accessed, it is taken from the table and assigned to a variable in order to be used. I think this is what it is talking about, but the scopes of the functions don't allow them to be accessed without getting them from the table. Unless this were assigned to a global variable I am not sure how these should/could be implemented. I could also be interpreting the meaning of this incorrectly and be missing what is required, so I will ask in slack to see if any previous members know what it means.