### PR TITLE
Added instructions for how to access executable and get it to run on MacOS - FIXES #105

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,21 @@ Requirements include:
 
 ## Creating an Executable
 
-- Note: How to access executable:
+- Note: How to access executable for Windows:
    1. Click on the 'Actions' tab in GitHub
    2. On the left-hand side under 'Workflows', click on '.github/workflows/create-executable.yml'
    3. Find your desired version (check title and branch name to find th eone you want) and then click on it
    4. Scroll down to the 'Artifacts' section and download Windows version.
 
--Note: For MacOS, follow the above instructions and then follow these below instructions:
-   1. Unzip the now downloaded folder
-   2. Go to winebottler.kronenberg.org and download the most recent version of WineBottler (4.x)
-   3. 
+-Note: How to access executable for MacOS:
+   1. Follow this tutorial until 4:10 in the video: https://youtu.be/5Z_G6QG7xxg?si=zg5MozBv6WrYJtIQ 
+   2. Once in the Windows virtual machine, follow the above instructions (steps 1-4) and then you will be able to run the executable on MacOS
+
+For MacOS 10.15 and newer:
+Follow this tutorial until 4:10:
+https://youtu.be/5Z_G6QG7xxg?si=zg5MozBv6WrYJtIQ 
+Then once in the Windows virtual machine, go to the SpeechTranscription git page and download the windows executable and then run it as you would on windows
+ 
 
 1. **Install requirements** - To run pyinstaller a couple of installations are necessary. These can be done with:
    *  pip install pyinstaller

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ Requirements include:
 -Note: How to access executable for MacOS:
    1. Follow this tutorial until 4:10 in the video: https://youtu.be/5Z_G6QG7xxg?si=zg5MozBv6WrYJtIQ 
    2. Once in the Windows virtual machine, follow the above instructions (steps 1-4) and then you will be able to run the executable on MacOS
-
-For MacOS 10.15 and newer:
-Follow this tutorial until 4:10:
-https://youtu.be/5Z_G6QG7xxg?si=zg5MozBv6WrYJtIQ 
-Then once in the Windows virtual machine, go to the SpeechTranscription git page and download the windows executable and then run it as you would on windows
  
 
 1. **Install requirements** - To run pyinstaller a couple of installations are necessary. These can be done with:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ Requirements include:
    1. Click on the 'Actions' tab in GitHub
    2. On the left-hand side under 'Workflows', click on '.github/workflows/create-executable.yml'
    3. Find your desired version (check title and branch name to find th eone you want) and then click on it
-   4. Scroll down to the 'Artifacts' section and download the MacOS or Windows version (depending on what OS you have)
+   4. Scroll down to the 'Artifacts' section and download Windows version.
+
+-Note: For MacOS, follow the above instructions and then follow these below instructions:
+   1. Unzip the now downloaded folder
+   2. Go to winebottler.kronenberg.org and download the most recent version of WineBottler (4.x)
+   3. 
 
 1. **Install requirements** - To run pyinstaller a couple of installations are necessary. These can be done with:
    *  pip install pyinstaller


### PR DESCRIPTION
Fixes #105 

**What was changed?**
I added a section in README.md that addresses how to use the executable if you have a Macbook or are running MacOS.

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
I changed the README.md documentation to add a section that describes how to run the executable on MacOS.

**Why was it changed?**
The executable did not work at all on MacOS before I figured out how to get it to work after many hours of testing and trial and error. I now am adding this section so that if a future developer or user is on MacOS, they can run the executable.

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
The executable is not able to be run on MacOS in any intuitive way. My code provides an instruction manual on how to be able to run the executable on MacOS.

**How was it changed?**
By adding instructions in README.md on how to run the executable on MacOS.

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
I modified README.md and the important lines are the lines under Creating an Executable that detail how to be able to run our executable file on MacOS.

**Screenshots that show the changes (if applicable):**
N/A
