### PR TITLE
Suppressed torchaudio warnings when launching program

### DIFF
--- a/diarizationAndTranscription.py
+++ b/diarizationAndTranscription.py
@@ -1,5 +1,8 @@
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from pyannote.audio import Pipeline
 from pydub import AudioSegment
-from pyannote.audio import Pipeline
 import whisper
 import os
 import re


### PR DESCRIPTION
Fixes #128 

**What was changed?**

Added a warning manager when importing pyannote which suppresses warnings given by deprecated code in the library.

**Why was it changed?**

When launching the program, multiple warnings would show in console, but have no impact on the performance of the application. Removing these improves clarity and prevents confusion for future developers. 

**How was it changed?**

Used the Python warnings library to put a general filter on the line (diarizationandtranscription.py line 3) that imports pyannote. This suppresses the warnings given by that library alone while leaving room for other warnings to show in the future. 

**Screenshots that show the changes (if applicable):**

![image](https://github.com/oss-slu/SpeechTranscription/assets/71533635/2cc4c865-e037-4043-8c37-be4dd84fa181)
