### PR TITLE
Suppressing warnings for whisper on import

### DIFF
--- a/diarizationAndTranscription.py
+++ b/diarizationAndTranscription.py
@@ -2,8 +2,8 @@ import warnings
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     from pyannote.audio import Pipeline
+    import whisper
 from pydub import AudioSegment
-import whisper
 import os
 import re
 from dotenv import load_dotenv


### PR DESCRIPTION
Fixes #147
**What was changed?**

Placed whisper's import under the same statement as pyannote's so both of their warnings are suppressed on startup. I have not encountered this warning before, so I am unsure if my changes have worked 100%.

**Why was it changed?**

Whisper seems to be sending a similar deprecation warning as pyannote was doing in a previous issue. Suppressing it will continue to prevent confusion for future developers.

**How was it changed?**

 - Moved whisper's import statement under the catch_warnings() manager. (diarizationandtranscription.py line 5)
 - The application still has full functionality on my end after the change was made.

**Screenshots that show the changes (if applicable):**

![image](https://github.com/oss-slu/SpeechTranscription/assets/71533635/5ffe92f0-37f1-4261-8dbd-1078a03f29a4)

