### PR TITLE
Added macos-setup.md file and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ffmpeg
 .env
 diarization.txt
 user_settings.txt
+venv/

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,14 +1,19 @@
-## Developer's Guide for Setting Up MacOS Environment
+## Developer's Guide for Setting Up Environment
 
 Ensure you have the following prerequisites downloaded:
 
 * `Java` --> [Download Here](https://www.oracle.com/java/technologies/downloads/)
 * `MySQL` --> [Download Here](https://dev.mysql.com/downloads/mysql/)
+* Python Version: `3.10.x - 3.11.x`
 
-Once those are downloaded and you have cloned the Git repository, you will want to go into the SpeechTranscription directory and create/activate a Python virtual environment:
+## Setting Up For MacOS:
+
+Once the prerequisites are downloaded and you have cloned the Git repository, you will want to go into the SpeechTranscription directory and create/activate a Python virtual environment:
 
 * `python3 -m venv venv` to create the environment.
 * `source venv/bin/activate` to activate.
+
+**Note: This environment will need to be activated everytime prior to running the program.**
 
 In order to install the dependencies from the requirements file, you will need to manually set the environment variables for mySQL. Enter these commands in your terminal:
 
@@ -19,7 +24,7 @@ Afterwards, enter the following command to install Homebrew for MacOS:
 
 `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 
-Note: After installation, Homebrew will prompt you to set up environment variables. Ensure you follow those instructions before proceeding.
+**Note: After installation, Homebrew will prompt you to set up environment variables. Ensure you follow those instructions before proceeding.**
 
 Once Homebrew is set up and installed, you can enter the following commands:
 
@@ -48,4 +53,35 @@ The 'nltk' library installation is more complex on MacOS.
 
     This is a temporary fix to use the nltk library for your current terminal session on MacOS. If you want to make these changes permanent, you must add the commands from step 2 to your .bash_profile.
 
-Finally, after running `git submodule init`, you should be able to run the program using `python GUI.py`.
+Finally, run these two commands:
+* `git submodule init` to initialize the submodules
+* `git submodule update` to ensure the submodules are up-to-date
+
+**You should now be able to run the program using `python GUI.py`.**
+
+## Setting Up For Windows/Linux:
+
+Once the prerequisites are downloaded and you have cloned the Git repository, you will want to go into the SpeechTranscription directory and follow these steps to download the 'nltk' library:
+
+```
+1. Run
+
+    pip install nltk
+
+    import nltk
+
+    nltk.download()
+
+2. Then click on the identifier 'all', and click 'Download'.
+```
+
+Now you may run the following command to install the required dependencies:
+
+`pip install requirements.txt`
+
+Finally, run these commands:
+
+* `git submodule init` to initialize the submodules
+* `git submodule update` to ensure the submodules are up-to-date
+
+**You should now be able to run the program using `python GUI.py`.**

--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ In this application, you can record live or upload an audio file form your compu
 
 ## Development Environment
 
-* If you are on MacOS, please refer to the macos-setup.md file.
-1. **Clone the Repository** - Clone the repository using 'git clone'
-2. **Requirements** - Install a compatible version of Python (list the compatible versions here) and run 'pip install requirements.txt'. Some requirements need to be installed through different methods. See requirements.txt for this. Must be using a 3.10.x - 3.11.x version of Python (check using 'python --version').
-3. **Load Sub-Modules** - Before launching the program, run the command 'git submodule init'
+For details on setting up the development environment, please refer to the [DEVELOPER_GUIDE.md](./DEVELOPER_GUIDE.md) file.
 
 ## Creating an Executable
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ In this application, you can record live or upload an audio file form your compu
 # Contributing as a Developer
 
 ## Development Environment
+
+* If you are on MacOS, please refer to the macos-setup.md file.
 1. **Clone the Repository** - Clone the repository using 'git clone'
 2. **Requirements** - Install a compatible version of Python (list the compatible versions here) and run 'pip install requirements.txt'. Some requirements need to be installed through different methods. See requirements.txt for this. Must be using a 3.10.x - 3.11.x version of Python (check using 'python --version').
 3. **Load Sub-Modules** - Before launching the program, run the command 'git submodule init'

--- a/macos-setup.md
+++ b/macos-setup.md
@@ -1,6 +1,6 @@
 ## Developer's Guide for Setting Up MacOS Environment
 
-Ensure you have the following prequisites downloaded:
+Ensure you have the following prerequisites downloaded:
 
 * `Java` --> [Download Here](https://www.oracle.com/java/technologies/downloads/)
 * `MySQL` --> [Download Here](https://dev.mysql.com/downloads/mysql/)

--- a/macos-setup.md
+++ b/macos-setup.md
@@ -1,0 +1,51 @@
+## Developer's Guide for Setting Up MacOS Environment
+
+Ensure you have the following prequisites downloaded:
+
+* `Java` --> [Download Here](https://www.oracle.com/java/technologies/downloads/)
+* `MySQL` --> [Download Here](https://dev.mysql.com/downloads/mysql/)
+
+Once those are downloaded and you have cloned the Git repository, you will want to go into the SpeechTranscription directory and create/activate a Python virtual environment:
+
+* `python3 -m venv venv` to create the environment.
+* `source venv/bin/activate` to activate.
+
+In order to install the dependencies from the requirements file, you will need to manually set the environment variables for mySQL. Enter these commands in your terminal:
+
+* `export MYSQLCLIENT_CFLAGS='pkg-config mysqlclient --cflags'`
+* `export MYSQLCLIENT_LDFLAGS='pkg-config mysqlclient --libs'`
+
+Afterwards, enter the following command to install Homebrew for MacOS:
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+Note: After installation, Homebrew will prompt you to set up environment variables. Ensure you follow those instructions before proceeding.
+
+Once Homebrew is set up and installed, you can enter the following commands:
+
+* `brew install mysql pkg-config`
+* `brew install portaudio`
+* `pip install pyaudio`
+
+Now you may run the `pip install -r requirements.txt` command to install the requirement dependencies.
+
+If installing requirements.txt file still won't run, then you may need to use the `pip3 install mysql-connector-python` command.
+
+The 'nltk' library installation is more complex on MacOS.
+
+    1. Install nltk and certifi via pip:
+        pip install nltk
+        pip3 install certifi
+
+    2. Enter the following commands to avoid SSL Certificate issues:
+        CERT_PATH=$(python -m certifi)
+        export SSL_CERT_FILE=${CERT_PATH}
+        export REQUESTS_CA_BUNDLE=${CERT_PATH}
+
+    3. Open Python Interpreter and import/download nltk:
+        >>> import nltk
+        >>> nltk.download()
+
+    This is a temporary fix to use the nltk library for your current terminal session on MacOS. If you want to make these changes permanent, you must add the commands from step 2 to your .bash_profile.
+
+Finally, after running `git submodule init`, you should be able to run the program using `python GUI.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,33 +30,7 @@ spectralcluster
 Resemblyzer
 
 #The 'nltk' library installation is more complex than just doing 'pip install nltk'.
-#This guide will show you how to install the 'nltk' library on different opertating systems (OS).
-#
-#MacOS: 
-#
-#    Perform the following steps to install nltk on MacOS. Do not include apostrophe's ( ' ' ) in command line:
-#
-#        1. Install nltk and ceertifi via pip:
-#            'pip install nltk'
-#            'pip3 install certifi'  
-#
-#        2. Open Python Interpreter and import/download nltk:
-#            'python'
-#            >>> 'import nltk'
-#            >>> 'nltk.download()'' 
-#
-#        3. Enter to following commands to avoid SSL Certificate issues:
-#            'CERT_PATH=$(python -m certifi)'
-#            'export SSL_CERT_FILE=${CERT_PATH}'
-#            'export REQUESTS_CA_BUNDLE=${CERT_PATH}'
-#
-#    The nltk library should now be ready to use on MacOS.
-#    
-#    However, this is only a temporary fix for your current terminal session.
-#    
-#    In order to permanently fix this problem, you must add the previous 3 lines (from the temporary fix) to your .bash_profile.
-#
-#
+#This guide will show you how to install the 'nltk' library on Windows & Linux operating systems.
 #
 #Windows & Linux:
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,13 +28,3 @@ pytest
 # Not currently in use - could be used for diarization in the future
 spectralcluster
 Resemblyzer
-
-#The 'nltk' library installation is more complex than just doing 'pip install nltk'.
-#This guide will show you how to install the 'nltk' library on Windows & Linux operating systems.
-#
-#Windows & Linux:
-#
-#    - 'pip install nltk'
-#    - 'import nltk'
-#    - 'nltk.download()'
-#    - Then click on the identifier 'all', then click 'Download'


### PR DESCRIPTION
Fixes #157 

**What was changed?**

* Added macos-setup.md file, which describes the steps for setting up MacOS developer environment.
* Added reference to the new markdown file in README.
* Removed the MacOS steps from the requirements.txt file.
* Updated the .gitignore file by adding venv/.

**Why was it changed?**

* The steps for MacOS setup were updated to be in order and listed everything that was missing and had to be downloaded.
* The prerequisites required for the environment were also mentioned to avoid any confusion.
* The steps in requirements.txt file for MacOS was out of order and did not work.
* The files were too large to be able to push so I had to add the virtual environment files to .gitignore.

**How was it changed?**

* When troubleshooting the issues with setting up the developer's environment, I kept a .txt file of all the commands I used. I used that Git history to figure out what steps I used to successfully set up my environment.
* I created the new markdown file by looking through my Git history, and I reorganized it into an order that made better sense/was easier to follow for the sake of the markdown file.
* I figured out I needed to add venv/ to the .gitignore file after attempting to push and getting an error that venv/ was too large to be pushed to the repo.