### PR TITLE
Fix for MacOS RuntimeWarning: Couldn't find ffmpeg or avconv

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -30,6 +30,7 @@ Once Homebrew is set up and installed, you can enter the following commands:
 
 * `brew install mysql pkg-config`
 * `brew install portaudio`
+# `brew install ffmpeg`
 * `pip install pyaudio`
 
 Now you may run the `pip install -r requirements.txt` command to install the requirement dependencies.


### PR DESCRIPTION
This PR fixes the following issue:

After following the developer guide on Mac OS and running the application, I get the following error in the terminal:
```
RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
```

**What was changed?**

Updated the MacOS section of DEVELOPER_GUIDE.md to install ffmpeg with homebrew.

**Why was it changed?**

Without installing ffmpeg with homebrew, I was unable to record an audio.