### PR TITLE
Working on automating build releases for merges to the main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - issue168_automated-releases
+      - main
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,57 +13,96 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         python-version: ['3.11', '3.12']
-      fail-fast: false  # Continue with other builds even if one fails
+      fail-fast: false
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4  # Updated to v4
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5  # Updated to v5
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install system dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install ffmpeg
+          brew install portaudio
+
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install ffmpeg
+          choco install portaudio
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install torch torchaudio
           pip install -r requirements.txt
+        continue-on-error: false
 
-      - name: Run tests
-        run: pytest
-        continue-on-error: true  # Allow the workflow to continue even if tests fail
+      - name: Install NLTK data
+        run: |
+          python -c "import nltk; nltk.download('all')"
+
+      - name: Run tests with detailed output
+        id: test
+        run: |
+          python -m pytest tests/ -v --junitxml=test-results.xml --capture=tee-sys > pytest-output.txt 2>&1
+        continue-on-error: true
+
+      - name: Display test output
+        if: always()
+        run: cat pytest-output.txt
+        shell: bash
+
+      - name: Store test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: |
+            test-results.xml
+            pytest-output.txt
+          if-no-files-found: warn
 
   release:
+    if: always()
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Explicitly grant permission to create releases
+      contents: write
       
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: test-results-*
+          merge-multiple: true
+
       - name: Generate release notes
-        id: generate_notes
         run: |
           echo "## Automated Release" > release_notes.md
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
+          echo "## Test Results" >> release_notes.md
+          echo "See attached test results in artifacts" >> release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1  # Using a more modern release action
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           body_path: release_notes.md
           draft: false
-          prerelease: false
+          prerelease: true
+          files: |
+            artifacts/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4  # Updated to v4
-        with:
-          name: build-artifact
-          path: ./dist/
-          if-no-files-found: warn  # Don't fail if dist directory is empty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build, Test, and Release on macOS and Windows
+
+on:
+  push:
+    branches:
+      - main  # Trigger on merge to the main branch
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest] 
+        python-version: ['3.11', '3.12']    
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest  # Modify if using a different test framework
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest  # Release only needs to run on one OS
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name: v${{ github.run_number }} 
+          release_name: Release ${{ github.run_number }}
+          body: |
+            Automatically generated release.
+            - OS: ${{ matrix.os }}
+            - Python Version: ${{ matrix.python-version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           name: Release ${{ github.run_number }}
           body_path: release_notes.md
           draft: false
-          prerelease: true
+          prerelease: false
           files: |
             artifacts/**
             Saltify.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-latest, windows-latest]
         python-version: ['3.11', '3.12']
       fail-fast: false
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,6 +86,11 @@ jobs:
           pattern: test-results-*
           merge-multiple: true
 
+      - name: Create project ZIP
+        run: |
+          # Create a ZIP of the entire project
+          zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
+
       - name: Generate release notes
         run: |
           echo "## Automated Release" > release_notes.md
@@ -93,6 +98,8 @@ jobs:
           echo "Commit: ${{ github.sha }}" >> release_notes.md
           echo "## Test Results" >> release_notes.md
           echo "See attached test results in artifacts" >> release_notes.md
+          echo "## Downloads" >> release_notes.md
+          echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -104,5 +111,6 @@ jobs:
           prerelease: true
           files: |
             artifacts/**
+            Saltify.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,24 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - issue168_automated-releases  # Trigger on push (merge) to the main branch
+      - issue168_automated-releases
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
+    
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]  # Run on macOS and Windows
-        python-version: ['3.11', '3.12']    # Python versions to test with (3.11.9 or greater)
+        os: [macos-latest, windows-latest]
+        python-version: ['3.11', '3.12']
+      fail-fast: false  # Continue with other builds even if one fails
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4  # Updated to v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5  # Updated to v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -29,33 +30,40 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: pytest  # Adjust based on your test framework
+        run: pytest
+        continue-on-error: true  # Allow the workflow to continue even if tests fail
 
   release:
-    needs: build  # Only run this after the build job succeeds
-    runs-on: ubuntu-latest  # Only needs one OS to create the release
-
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Explicitly grant permission to create releases
+      
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Generate release notes
+        id: generate_notes
+        run: |
+          echo "## Automated Release" > release_notes.md
+          echo "Build number: ${{ github.run_number }}" >> release_notes.md
+          echo "Commit: ${{ github.sha }}" >> release_notes.md
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub provides this automatically
+        uses: softprops/action-gh-release@v1  # Using a more modern release action
         with:
-          tag_name: v${{ github.run_number }}  # Use the run number as the version
-          release_name: Release ${{ github.run_number }}
-          body: |
-            Automatically generated release.
-            - OS: ${{ matrix.os }}
-            - Python Version: ${{ matrix.python-version }}
+          tag_name: v${{ github.run_number }}
+          name: Release ${{ github.run_number }}
+          body_path: release_notes.md
           draft: false
           prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4  # Updated to v4
         with:
           name: build-artifact
-          path: ./dist/  # Adjust this to your project's output directory
+          path: ./dist/
+          if-no-files-found: warn  # Don't fail if dist directory is empty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - main  # Trigger on merge to the main branch
+      - issue168_automated-releases  # Trigger on push (merge) to the main branch
 
 jobs:
   build:
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest] 
-        python-version: ['3.11', '3.12']    
+        os: [macos-latest, windows-latest]  # Run on macOS and Windows
+        python-version: ['3.11', '3.12']    # Python versions to test with (3.11.9 or greater)
 
     steps:
       - name: Checkout code
@@ -29,11 +29,11 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: pytest  # Modify if using a different test framework
+        run: pytest  # Adjust based on your test framework
 
   release:
-    needs: build
-    runs-on: ubuntu-latest  # Release only needs to run on one OS
+    needs: build  # Only run this after the build job succeeds
+    runs-on: ubuntu-latest  # Only needs one OS to create the release
 
     steps:
       - name: Checkout code
@@ -43,9 +43,9 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub provides this automatically
         with:
-          tag_name: v${{ github.run_number }} 
+          tag_name: v${{ github.run_number }}  # Use the run number as the version
           release_name: Release ${{ github.run_number }}
           body: |
             Automatically generated release.
@@ -58,3 +58,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-artifact
+          path: ./dist/  # Adjust this to your project's output directory


### PR DESCRIPTION
…releases whenever a merge to the main branch happens

Fixes #168 

**What was changed?**

*Added a release.yml file to the workflows folder in order to automate the creation of build releases with a merge to the main branch*

**Why was it changed?**

*Currently, there aren't any build releases being made when a merge to the main branch occurs. This .yml file is meant to help automate this process with each merge to the main.*

**How was it changed?**

*I had to add a new file to the workflows folder in order to automate the process of build release creation. I had to include sections to ensure that this is compatible for both mac and windows as well as the python version required.*

**Screenshots that show the changes (if applicable):**

