### PR TITLE
Issue178 build test failures

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -5,6 +5,7 @@ on:
       - fix-mac-exe
       - testingv4artifact
       - issue169_dependency
+      - issue178_build-test-failures
 
 jobs:
   build-macos:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -21,24 +21,21 @@ jobs:
           if ! java -version; then
             brew install openjdk@11
           fi
-
       - name: Install Specific Python Version
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.7
-
       - name: Install NLTK
         run: |
           pip install nltk
           python -m nltk.downloader all
-          
       - run: brew install mysql pkg-config portaudio
       - run: pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
       - run: pip uninstall -y typing
-      - run: pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
+      - name: Build executable
+        run: pyinstaller --name Saltify --windowed --noconfirm --onefile -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: SpeechTranscription_macos
-          path: dist/Saltify/*
-
+          path: dist/Saltify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
           name: SpeechTranscription_windows
           path: artifacts/windows
 
+      - name: Verify Artifacts Downloaded
+        run: |
+          echo "Listing contents of artifacts/macos:"
+          ls artifacts/macos || echo "No macOS artifacts found."
+          echo "Listing contents of artifacts/windows:"
+          ls artifacts/windows || echo "No Windows artifacts found."
+
       - name: Generate release notes
         run: |
           echo "## Automated Release" > release_notes.md
@@ -48,8 +55,9 @@ jobs:
 
       - name: Create Release and Upload Assets
         run: |
+          # Adjust file paths as needed to specify specific files instead of directories.
           gh release create v${{ github.run_number }} \
             -t "Release ${{ github.run_number }}" \
             -F release_notes.md \
-            artifacts/macos \
-            artifacts/windows
+            artifacts/macos/* \
+            artifacts/windows/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,39 +3,50 @@ name: Release
 on:
   push:
     branches:
-      - issue178_build-test-failures  # Specify your target branch
+      - issue178_build-test-failures
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
       - completed
 
+permissions:
+  contents: write
+  packages: read
+  actions: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
+    if: |
+      github.event_name == 'push' || 
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'  # Specify Node 20 explicitly
-
       - name: Checkout code
-        uses: actions/checkout@v3  # Latest version
+        uses: actions/checkout@v4
 
       - name: Download macOS build artifacts
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download Windows build artifacts
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: List artifacts (debug)
+        run: |
+          echo "Contents of artifacts directory:"
+          ls -R artifacts/
 
       - name: Create project ZIP
         run: |
@@ -46,11 +57,18 @@ jobs:
           echo "## Automated Release" > release_notes.md
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
+          echo "Branch: ${{ github.ref_name }}" >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
+          if [ -d "artifacts/macos" ]; then
+            echo "- macOS build included" >> release_notes.md
+          fi
+          if [ -d "artifacts/windows" ]; then
+            echo "- Windows build included" >> release_notes.md
+          fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1  # Use latest stable version
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
@@ -58,7 +76,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            artifacts/**
+            artifacts/**/*
             Saltify.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release:
     # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1.1.0
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,169 +1,50 @@
-name: Build, Test, and Release on macOS and Windows
+name: Release
 
 on:
   push:
     branches:
-      - issue178_build-test-failures
+      - issue178_build-test-failures  # Specify your target branch
+  workflow_run:
+    workflows: ["macos-build", "windows-build"]
+    types:
+      - completed
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-        python-version: ['3.11', '3.12']
-      fail-fast: false
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew update
-          brew install ffmpeg portaudio libomp cmake pkg-config --quiet || echo "Brew install failed"
-      
-      - name: Install system dependencies (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          choco install ffmpeg --verbose
-          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose || echo "Choco install failed"
-
-      - name: Install critical Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install torch==2.0.0 torchaudio==2.0.1 || echo "Torch/Torchaudio install failed"
-          pip install -r requirements.txt || echo "Requirements install failed"
-
-      - name: Install NLTK data
-        run: |
-          python -c "import nltk; nltk.download('all')"
-
-      - name: Run tests and save output
-        run: |
-          mkdir -p test-output
-          python -m pytest tests/ -v > test-output/pytest-output.txt || echo "Tests encountered an error"
-      
-      - name: Ensure test output exists
-        run: |
-          if [ ! -s test-output/pytest-output.txt ]; then echo "No output generated. Tests may have failed." > test-output/pytest-output.txt; fi
-
-      - name: Display test output
-        run: |
-          cat test-output/pytest-output.txt || echo "No pytest output available."
-
-      - name: Upload test results as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: test-output/pytest-output.txt
-          if-no-files-found: warn
-
-  macos-build:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11.7
-      - name: Install Java
-        run: |
-          if ! java -version; then
-            brew install openjdk@11
-          fi
-      - name: Install NLTK
-        run: |
-          pip install nltk
-          python -m nltk.downloader all
-      - name: Install additional dependencies
-        run: |
-          brew install mysql pkg-config portaudio
-          pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
-          pip uninstall -y typing
-      - name: Create macOS executable
-        run: |
-          pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
-      - name: Upload macOS artifact
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: SpeechTranscription_macos
-          path: dist/Saltify/*
-
-  windows-build:
-    runs-on: windows-latest
-  
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11.7
-      - name: Install Java
-        shell: powershell
-        run: |
-          if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
-            Write-Host "Java not found, installing JDK 11..."
-            choco install jdk11 -y
-          }
-      - name: Install NLTK
-        run: |
-          pip install nltk
-          python -m nltk.downloader punkt
-      - name: Install additional dependencies
-        run: |
-          pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
-          pip uninstall -y typing
-      - name: Create Windows executable
-        run: |
-          pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
-      - name: Upload Windows artifact
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: SpeechTranscription_windows
-          path: dist/Saltify/*
-
   release:
-    if: always()
-    needs: [build, macos-build, windows-build]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Download test results
+
+      - name: Download macOS build artifacts
+        if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v4
         with:
-          path: artifacts
-          pattern: test-results-*
-          merge-multiple: true
+          name: SpeechTranscription_macos
+          path: artifacts/macos
+
+      - name: Download Windows build artifacts
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: SpeechTranscription_windows
+          path: artifacts/windows
+
       - name: Create project ZIP
         run: |
           zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
+
       - name: Generate release notes
         run: |
           echo "## Automated Release" > release_notes.md
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
-          echo "## Test Results" >> release_notes.md
-          echo "See attached test results in artifacts" >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
-      - name: Create Release
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - issue178_build-test-failures
-
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
@@ -17,8 +13,9 @@ permissions:
 
 jobs:
   release:
-    # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Runs only if both `macos-build` and `windows-build` succeeded after a push to `issue178_build-test-failures`
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'issue178_build-test-failures' }}
+    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,94 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - issue178_build-test-failures
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
       - completed
-  push:
-    branches:
-      - issue178_build-test-failures
+
+permissions:
+  contents: write
+  packages: read
+  actions: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.workflow == 'macos-build' || github.event.workflow == 'windows-build' }}
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create artifacts directory
+        run: mkdir -p artifacts/macos artifacts/windows
+      - name: Debug Event Info
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Event path: ${{ github.event_path }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "Workflow run ID: ${{ github.event.workflow_run.id }}"
+            echo "Workflow name: ${{ github.event.workflow_run.name }}"
+            echo "Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
+          fi
       - name: Download macOS build artifacts
-        if: ${{ github.event.workflow == 'macos-build' && github.event.conclusion == 'success' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'macos-build' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download Windows build artifacts
-        if: ${{ github.event.workflow == 'windows-build' && github.event.conclusion == 'success' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'windows-build' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Verify Artifacts Directory Structure
+      - name: List directory structure
         run: |
-          echo "Root directory structure:"
-          ls -R
-          echo "Checking artifacts/macos:"
-          ls -R artifacts/macos || echo "No macOS artifacts found."
-          echo "Checking artifacts/windows:"
-          ls -R artifacts/windows || echo "No Windows artifacts found."
-
-      - name: Generate release notes
+          echo "Full directory structure:"
+          find . -type f -not -path "./.git/*"
+          
+          echo "Contents of artifacts directory:"
+          ls -la artifacts/
+          ls -la artifacts/macos || echo "No macOS artifacts"
+          ls -la artifacts/windows || echo "No Windows artifacts"
+      - name: Create project ZIP
         run: |
-          echo "## Automated Release" > release_notes.md
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
+          echo "Branch: ${{ github.ref_name }}" >> release_notes.md
+          echo "Event type: ${{ github.event_name }}" >> release_notes.md
           echo "## Downloads" >> release_notes.md
-          echo "- macOS and Windows build artifacts included." >> release_notes.md
-
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
-
-      - name: Authenticate GitHub CLI
-        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Create Release and Upload Assets
-        run: |
-          gh release create v${{ github.run_number }} \
-            -t "Release ${{ github.run_number }}" \
-            -F release_notes.md \
-            artifacts/macos/* \
-            artifacts/windows/*
+          echo "- Saltify.zip: Complete project source code" >> release_notes.md
+          
+          if [ -d "artifacts/macos" ] && [ "$(ls -A artifacts/macos)" ]; then
+            echo "- macOS build included" >> release_notes.md
+          else
+            echo "Note: macOS build not available for this release" >> release_notes.md
+          fi
+          
+          if [ -d "artifacts/windows" ] && [ "$(ls -A artifacts/windows)" ]; then
+            echo "- Windows build included" >> release_notes.md
+          else
+            echo "Note: Windows build not available for this release" >> release_notes.md
+          fi
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release ${{ github.run_number }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+          files: |
+            artifacts/**/*
+            Saltify.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - issue178_build-test-failures
+
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
@@ -16,41 +17,28 @@ permissions:
 
 jobs:
   release:
+    # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Create artifacts directory
         run: mkdir -p artifacts/macos artifacts/windows
-      - name: Debug Event Info
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Event path: ${{ github.event_path }}"
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "Workflow run ID: ${{ github.event.workflow_run.id }}"
-            echo "Workflow name: ${{ github.event.workflow_run.name }}"
-            echo "Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
-          fi
+
       - name: Download macOS build artifacts
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'macos-build' }}
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download Windows build artifacts
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'windows-build' }}
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
 
       - name: List directory structure
         run: |
@@ -61,6 +49,7 @@ jobs:
           ls -la artifacts/
           ls -la artifacts/macos || echo "No macOS artifacts"
           ls -la artifacts/windows || echo "No Windows artifacts"
+
       - name: Create project ZIP
         run: |
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
@@ -81,6 +70,7 @@ jobs:
           else
             echo "Note: Windows build not available for this release" >> release_notes.md
           fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Log System Information
-        run: |
-          echo "Python version:"
-          python --version
-          echo "Pip version:"
-          pip --version
-          echo "System Information:"
-          uname -a
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -37,49 +28,42 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ffmpeg portaudio libomp cmake pkg-config
-          echo "Brew installed packages:"
-          brew list
-
+          brew install ffmpeg portaudio libomp cmake pkg-config --quiet || echo "Brew install failed"
+      
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
           choco install ffmpeg --verbose
-          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose
-          echo "Chocolatey installed packages:"
-          choco list --local-only
+          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose || echo "Choco install failed"
 
-      - name: Install critical Python dependencies separately
+      - name: Install critical Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch==2.0.0 torchaudio==2.0.1 --verbose || echo "Torch/Torchaudio installation failed"
-          pip install -r requirements.txt --verbose || echo "Requirements installation failed"
+          pip install torch==2.0.0 torchaudio==2.0.1 || echo "Torch/Torchaudio install failed"
+          pip install -r requirements.txt || echo "Requirements install failed"
 
       - name: Install NLTK data
         run: |
           python -c "import nltk; nltk.download('all')"
 
-      - name: Run tests without output redirection
+      - name: Run tests and save output
         run: |
           mkdir -p test-output
-          python -m pytest tests/ -v || echo "Tests encountered an error"
-        continue-on-error: true
-
-      - name: Ensure test output file exists
+          python -m pytest tests/ -v > test-output/pytest-output.txt || echo "Tests encountered an error"
+      
+      - name: Ensure test output exists
         run: |
-          touch test-output/pytest-output.txt
+          if [ ! -s test-output/pytest-output.txt ]; then echo "No output generated. Tests may have failed." > test-output/pytest-output.txt; fi
 
       - name: Display test output
         run: |
           cat test-output/pytest-output.txt || echo "No pytest output available."
 
-      - name: Store test results
-        if: always()
+      - name: Upload test results as artifacts
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            test-output/pytest-output.txt
+          path: test-output/pytest-output.txt
           if-no-files-found: warn
 
   release:
@@ -115,7 +99,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v1.1.0
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - issue178_build-test-failures  # Change to 'main' when deploying
+      - main  # Changed from issue178_build-test-failures to main
 
 jobs:
   build:
@@ -23,41 +23,70 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'  # Enable pip caching
 
+      # macOS-specific system dependencies
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ffmpeg portaudio libomp cmake --verbose  # Use verbose for detailed logs
+          brew install ffmpeg portaudio pkg-config
+          export LDFLAGS="-L/usr/local/lib"
+          export CPPFLAGS="-I/usr/local/include"
+          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
 
+      # Windows-specific system dependencies
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install ffmpeg --verbose
-          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose
+          choco install ffmpeg -y
+          # Download and extract PortAudio manually for Windows
+          curl -L https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz -o portaudio.tgz
+          tar xf portaudio.tgz
+          cd portaudio
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --config Release
+          cmake --install . --config Release
 
+      # Install Python dependencies with better error handling
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install torch==2.0.0 torchaudio==2.0.1 --verbose  # Verbose for detailed output
-          pip install -r requirements.txt --verbose
-        continue-on-error: false
+          python -m pip install --upgrade pip wheel setuptools
+          # Install PyTorch and torchaudio first
+          python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+          # Install other dependencies with verbose output
+          python -m pip install -v -r requirements.txt
+        env:
+          # Set environment variables for building binary wheels
+          SYSTEM_VERSION_COMPAT: 0  # For macOS
+          CMAKE_GENERATOR: "Visual Studio 17 2022"  # For Windows
 
       - name: Install NLTK data
         run: |
-          python -c "import nltk; nltk.download('all')"
+          python -c "import nltk; nltk.download('all', quiet=True)"
 
+      # Create test output directory
+      - name: Create test output directory
+        run: mkdir -p test_output
+
+      # Run tests with proper output handling
       - name: Run tests with detailed output
         id: test
         run: |
-          mkdir -p test-output  # Ensure output folder exists
-          python -m pytest tests/ -v --junitxml=test-results.xml --capture=tee-sys > test-output/pytest-output.txt 2>&1
+          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1
         continue-on-error: true
 
       - name: Display test output
         if: always()
-        run: cat test-output/pytest-output.txt
         shell: bash
+        run: |
+          if [ -f "test_output/pytest-output.txt" ]; then
+            cat test_output/pytest-output.txt
+          else
+            echo "Test output file not found"
+          fi
 
       - name: Store test results
         if: always()
@@ -65,12 +94,12 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
-            test-results.xml
-            test-output/pytest-output.txt
+            test_output/test-results.xml
+            test_output/pytest-output.txt
           if-no-files-found: warn
 
   release:
-    if: always()
+    if: success() # Only create release if builds succeed
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,15 @@
-name: Build, Test, and Release on macOS and Windows
+name: Build, Test, and Release
 
 on:
   push:
     branches:
-      - main  # Changed from issue178_build-test-failures to main
+      - issue178_build-test-failures  # Changed back to your test branch
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    
+  macos-build:
+    runs-on: macos-latest
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
         python-version: ['3.11', '3.12']
       fail-fast: false
     
@@ -23,84 +21,147 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'  # Enable pip caching
+          cache: 'pip'
 
-      # macOS-specific system dependencies
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
+      - name: Debug Environment
+        run: |
+          echo "Python version:"
+          python --version
+          echo "Pip version:"
+          pip --version
+          echo "System info:"
+          sw_vers
+          echo "Brew info:"
+          brew --version
+
+      - name: Install system dependencies
         run: |
           brew update
           brew install ffmpeg portaudio pkg-config
-          export LDFLAGS="-L/usr/local/lib"
-          export CPPFLAGS="-I/usr/local/include"
-          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
+          echo "Installed packages:"
+          brew list
+          echo "PortAudio location:"
+          brew list portaudio
 
-      # Windows-specific system dependencies
-      - name: Install system dependencies (Windows)
-        if: runner.os == 'Windows'
+      - name: Set environment variables
         run: |
-          choco install ffmpeg -y
-          # Download and extract PortAudio manually for Windows
-          curl -L https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz -o portaudio.tgz
-          tar xf portaudio.tgz
-          cd portaudio
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build . --config Release
-          cmake --install . --config Release
+          echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I/usr/local/include" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig" >> $GITHUB_ENV
+          echo "Environment variables set:"
+          env | grep -E "LDFLAGS|CPPFLAGS|PKG_CONFIG_PATH"
 
-      # Install Python dependencies with better error handling
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          # Install PyTorch and torchaudio first
           python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-          # Install other dependencies with verbose output
           python -m pip install -v -r requirements.txt
-        env:
-          # Set environment variables for building binary wheels
-          SYSTEM_VERSION_COMPAT: 0  # For macOS
-          CMAKE_GENERATOR: "Visual Studio 17 2022"  # For Windows
+          echo "Installed Python packages:"
+          pip list
 
       - name: Install NLTK data
         run: |
           python -c "import nltk; nltk.download('all', quiet=True)"
+          echo "NLTK data directory:"
+          python -c "import nltk; print(nltk.data.path)"
 
-      # Create test output directory
-      - name: Create test output directory
-        run: mkdir -p test_output
-
-      # Run tests with proper output handling
-      - name: Run tests with detailed output
-        id: test
+      - name: Run tests
         run: |
-          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1
-        continue-on-error: true
+          mkdir -p test_output
+          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1 || true
+          echo "Test output directory contents:"
+          ls -la test_output/
 
-      - name: Display test output
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
         if: always()
-        shell: bash
-        run: |
-          if [ -f "test_output/pytest-output.txt" ]; then
-            cat test_output/pytest-output.txt
-          else
-            echo "Test output file not found"
-          fi
+        with:
+          name: test-results-macos-${{ matrix.python-version }}
+          path: test_output
+          if-no-files-found: warn
 
-      - name: Store test results
+  windows-build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+      fail-fast: false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Debug Environment
+        shell: pwsh
+        run: |
+          Write-Host "Python version:"
+          python --version
+          Write-Host "Pip version:"
+          pip --version
+          Write-Host "System info:"
+          systeminfo | select-string "OS"
+
+      - name: Install FFmpeg
+        shell: pwsh
+        run: |
+          choco install ffmpeg -y
+          Write-Host "FFmpeg version:"
+          ffmpeg -version
+
+      - name: Install PortAudio
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz" -OutFile "portaudio.tgz"
+          tar -xf portaudio.tgz
+          cd portaudio
+          mkdir build
+          cd build
+          cmake .. -G "Visual Studio 17 2022" -A x64
+          cmake --build . --config Release
+          cmake --install . --config Release
+          Write-Host "PortAudio installation completed"
+          dir "C:\Program Files\PortAudio"
+
+      - name: Install Python dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -v -r requirements.txt
+          Write-Host "Installed Python packages:"
+          pip list
+
+      - name: Install NLTK data
+        shell: pwsh
+        run: |
+          python -c "import nltk; nltk.download('all', quiet=True)"
+          python -c "import nltk; print(nltk.data.path)"
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          mkdir test_output -ErrorAction SilentlyContinue
+          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1
+          Write-Host "Test output directory contents:"
+          dir test_output
+
+      - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            test_output/test-results.xml
-            test_output/pytest-output.txt
+          name: test-results-windows-${{ matrix.python-version }}
+          path: test_output
           if-no-files-found: warn
 
-  release:
-    if: success() # Only create release if builds succeed
-    needs: build
+  create-release:
+    needs: [macos-build, windows-build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -109,26 +170,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download test results
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: test-results-*
           merge-multiple: true
 
+      - name: Debug artifacts
+        run: |
+          echo "Contents of artifacts directory:"
+          ls -R artifacts/
+          
       - name: Create project ZIP
         run: |
           zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
+          echo "Created ZIP file:"
+          ls -lh Saltify.zip
 
       - name: Generate release notes
         run: |
-          echo "## Automated Release" > release_notes.md
-          echo "Build number: ${{ github.run_number }}" >> release_notes.md
-          echo "Commit: ${{ github.sha }}" >> release_notes.md
-          echo "## Test Results" >> release_notes.md
-          echo "See attached test results in artifacts" >> release_notes.md
-          echo "## Downloads" >> release_notes.md
-          echo "- Saltify.zip: Complete project source code" >> release_notes.md
+          {
+            echo "## Automated Release"
+            echo "Build number: ${{ github.run_number }}"
+            echo "Commit: ${{ github.sha }}"
+            echo "## Test Results"
+            echo "Test results from macOS and Windows builds are attached."
+            echo "## Downloads"
+            echo "- Saltify.zip: Complete project source code"
+          } > release_notes.md
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -139,7 +209,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            artifacts/**
+            artifacts/**/*
             Saltify.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,45 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - issue178_build-test-failures  # Specify your target branch
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
       - completed
+  push:
+    branches:
+      - issue178_build-test-failures
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
+    if: ${{ github.event_name == 'push' || github.event.workflow == 'macos-build' || github.event.workflow == 'windows-build' }}
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Download macOS build artifacts
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event.workflow == 'macos-build' && github.event.conclusion == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
 
       - name: Download Windows build artifacts
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event.workflow == 'windows-build' && github.event.conclusion == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
 
-      - name: Verify Artifacts Downloaded
+      - name: Verify Artifacts Directory Structure
         run: |
-          echo "Listing contents of artifacts/macos:"
-          ls artifacts/macos || echo "No macOS artifacts found."
-          echo "Listing contents of artifacts/windows:"
-          ls artifacts/windows || echo "No Windows artifacts found."
+          echo "Root directory structure:"
+          ls -R
+          echo "Checking artifacts/macos:"
+          ls -R artifacts/macos || echo "No macOS artifacts found."
+          echo "Checking artifacts/windows:"
+          ls -R artifacts/windows || echo "No Windows artifacts found."
 
       - name: Generate release notes
         run: |
@@ -55,7 +57,6 @@ jobs:
 
       - name: Create Release and Upload Assets
         run: |
-          # Adjust file paths as needed to specify specific files instead of directories.
           gh release create v${{ github.run_number }} \
             -t "Release ${{ github.run_number }}" \
             -F release_notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,78 @@ jobs:
           path: test-output/pytest-output.txt
           if-no-files-found: warn
 
+  macos-build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.7
+      - name: Install Java
+        run: |
+          if ! java -version; then
+            brew install openjdk@11
+          fi
+      - name: Install NLTK
+        run: |
+          pip install nltk
+          python -m nltk.downloader all
+      - name: Install additional dependencies
+        run: |
+          brew install mysql pkg-config portaudio
+          pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
+          pip uninstall -y typing
+      - name: Create macOS executable
+        run: |
+          pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: SpeechTranscription_macos
+          path: dist/Saltify/*
+
+  windows-build:
+    runs-on: windows-latest
+  
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.7
+      - name: Install Java
+        shell: powershell
+        run: |
+          if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
+            Write-Host "Java not found, installing JDK 11..."
+            choco install jdk11 -y
+          }
+      - name: Install NLTK
+        run: |
+          pip install nltk
+          python -m nltk.downloader punkt
+      - name: Install additional dependencies
+        run: |
+          pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
+          pip uninstall -y typing
+      - name: Create Windows executable
+        run: |
+          pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: SpeechTranscription_windows
+          path: dist/Saltify/*
+
   release:
     if: always()
-    needs: build
+    needs: [build, macos-build, windows-build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -76,18 +145,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Download test results
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: test-results-*
           merge-multiple: true
-
       - name: Create project ZIP
         run: |
           zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
-
       - name: Generate release notes
         run: |
           echo "## Automated Release" > release_notes.md
@@ -97,7 +163,6 @@ jobs:
           echo "See attached test results in artifacts" >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,42 +1,35 @@
 name: Release
-
 on:
-  workflow_run:
-    workflows: ["macos-build", "windows-build"]
+  push:
     branches:
       - issue178_build-test-failures
-    types:
-      - completed
-
 permissions:
   contents: write
   packages: read
   actions: read
-
 jobs:
+  call-macos-build:
+    uses: oss-slu/SpeechTranscription/.github/workflows/macos-build.yml@build_fixes_copy
+  call-windows-build:
+    uses: oss-slu/SpeechTranscription/.github/workflows/windows-build.yml@build_fixes_copy
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: [call-macos-build, call-windows-build]
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Create artifacts directory
         run: mkdir -p artifacts/macos artifacts/windows
-
       - name: Download macOS build artifacts
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
-
       - name: Download Windows build artifacts
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
-
       - name: List directory structure
         run: |
           echo "Full directory structure:"
@@ -46,7 +39,6 @@ jobs:
           ls -la artifacts/
           ls -la artifacts/macos || echo "No macOS artifacts"
           ls -la artifacts/windows || echo "No Windows artifacts"
-
       - name: Create project ZIP
         run: |
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
@@ -54,28 +46,20 @@ jobs:
           echo "Branch: ${{ github.ref_name }}" >> release_notes.md
           echo "Event type: ${{ github.event_name }}" >> release_notes.md
           echo "## Downloads" >> release_notes.md
-          echo "- Saltify.zip: Complete project source code" >> release_notes.md
           
           if [ -d "artifacts/macos" ] && [ "$(ls -A artifacts/macos)" ]; then
-            echo "- macOS build included" >> release_notes.md
+            echo "- macOS executable included" >> release_notes.md
+            zip -r artifacts/Saltify_macos.zip artifacts/macos/*
           else
-            echo "Note: macOS build not available for this release" >> release_notes.md
+            echo "Note: macOS executable not available for this release" >> release_notes.md
           fi
           
           if [ -d "artifacts/windows" ] && [ "$(ls -A artifacts/windows)" ]; then
-            echo "- Windows build included" >> release_notes.md
+            echo "- Windows executable included" >> release_notes.md
+            zip -r artifacts/Saltify_windows.zip artifacts/windows/*
           else
-            echo "Note: Windows build not available for this release" >> release_notes.md
+            echo "Note: Windows executable not available for this release" >> release_notes.md
           fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ github.run_number }}
-          name: Release ${{ github.run_number }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: false
-          files: |
-            artifacts/**/*
-            Saltify.zip
+          
+          echo "- Saltify_macos.zip: macOS executable" >> release_notes.md
+          echo "- Saltify_windows.zip: Windows executable" >> release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v1.1.0  # Updated to avoid Node.js deprecation warning
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,14 @@ jobs:
           
           if [ -d "artifacts/macos" ] && [ "$(ls -A artifacts/macos)" ]; then
             echo "- macOS executable included" >> release_notes.md
-            zip -r artifacts/Saltify_macos.zip artifacts/macos/*
+            zip -j artifacts/Saltify_macos.zip artifacts/macos/*
           else
             echo "Note: macOS executable not available for this release" >> release_notes.md
           fi
           
           if [ -d "artifacts/windows" ] && [ "$(ls -A artifacts/windows)" ]; then
             echo "- Windows executable included" >> release_notes.md
-            zip -r artifacts/Saltify_windows.zip artifacts/windows/*
+            zip -j artifacts/Saltify_windows.zip artifacts/windows/*
           else
             echo "Note: Windows executable not available for this release" >> release_notes.md
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,54 +28,46 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ffmpeg portaudio libomp cmake pkg-config --quiet
-          brew link --overwrite ffmpeg portaudio libomp cmake pkg-config || true
-
+          brew install ffmpeg portaudio libomp cmake pkg-config --quiet || echo "Brew install failed"
+      
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install ffmpeg --no-progress
-          choco install -y portaudio --source=https://community.chocolatey.org/api/v2/ --no-progress
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Choco install had non-zero exit code but continuing..."
-          }
+          choco install ffmpeg --verbose
+          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose || echo "Choco install failed"
 
       - name: Install critical Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel
-          
-          # Install PyTorch with specific version based on OS
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            pip install torch==2.0.0+cpu torchaudio==2.0.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
-          else
-            pip install torch==2.0.0 torchaudio==2.0.1
-          fi
-          
-          # Install requirements with detailed error logging
-          pip install -r requirements.txt -v
+          pip install torch==2.0.0 torchaudio==2.0.1 || echo "Torch/Torchaudio install failed"
+          pip install -r requirements.txt || echo "Requirements install failed"
 
       - name: Install NLTK data
         run: |
-          python -c "import nltk; nltk.download('all', quiet=True)"
+          python -c "import nltk; nltk.download('all')"
 
-      - name: Run tests
+      - name: Run tests and save output
         run: |
           mkdir -p test-output
-          python -m pytest tests/ -v --capture=tee-sys
+          python -m pytest tests/ -v > test-output/pytest-output.txt || echo "Tests encountered an error"
+      
+      - name: Ensure test output exists
+        run: |
+          if [ ! -s test-output/pytest-output.txt ]; then echo "No output generated. Tests may have failed." > test-output/pytest-output.txt; fi
 
-      - name: Upload test results
+      - name: Display test output
+        run: |
+          cat test-output/pytest-output.txt || echo "No pytest output available."
+
+      - name: Upload test results as artifacts
         uses: actions/upload-artifact@v4
-        if: always()  # Upload even if tests fail
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            test-output/
-            .pytest_cache/
-            pytest-logs.txt
+          path: test-output/pytest-output.txt
           if-no-files-found: warn
 
   release:
+    if: always()
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -84,15 +76,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for proper versioning
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'  # Use latest LTS version
-
-      - name: Download all artifacts
+      - name: Download test results
         uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -109,8 +94,7 @@ jobs:
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
           echo "## Test Results" >> release_notes.md
-          echo "Test results summary:" >> release_notes.md
-          find artifacts -type f -exec cat {} \; >> release_notes.md
+          echo "See attached test results in artifacts" >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,13 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
     
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'  # Specify Node 20 explicitly
+
       - name: Checkout code
-        uses: actions/checkout@v3  # Uses latest version, will migrate to Node 20 automatically
+        uses: actions/checkout@v3  # Latest version
 
       - name: Download macOS build artifacts
         if: ${{ github.event_name == 'workflow_run' }}
@@ -45,7 +50,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1  # Latest stable version
+        uses: softprops/action-gh-release@v1.37.0  # Updated to the latest stable version
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,32 @@ jobs:
           
           echo "- Saltify_macos.zip: macOS executable" >> release_notes.md
           echo "- Saltify_windows.zip: Windows executable" >> release_notes.md
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.run_number }}
+          release_name: Release ${{ github.run_number }}
+          body_path: ./release_notes.md
+          draft: false
+          prerelease: false
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/Saltify_macos.zip
+          asset_name: Saltify_macos.zip
+          asset_content_type: application/zip
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/Saltify_windows.zip
+          asset_name: Saltify_windows.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,46 +28,54 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ffmpeg portaudio libomp cmake pkg-config --quiet || echo "Brew install failed"
-      
+          brew install ffmpeg portaudio libomp cmake pkg-config --quiet
+          brew link --overwrite ffmpeg portaudio libomp cmake pkg-config || true
+
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install ffmpeg --verbose
-          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose || echo "Choco install failed"
+          choco install ffmpeg --no-progress
+          choco install -y portaudio --source=https://community.chocolatey.org/api/v2/ --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Choco install had non-zero exit code but continuing..."
+          }
 
       - name: Install critical Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch==2.0.0 torchaudio==2.0.1 || echo "Torch/Torchaudio install failed"
-          pip install -r requirements.txt || echo "Requirements install failed"
+          python -m pip install setuptools wheel
+          
+          # Install PyTorch with specific version based on OS
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            pip install torch==2.0.0+cpu torchaudio==2.0.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          else
+            pip install torch==2.0.0 torchaudio==2.0.1
+          fi
+          
+          # Install requirements with detailed error logging
+          pip install -r requirements.txt -v
 
       - name: Install NLTK data
         run: |
-          python -c "import nltk; nltk.download('all')"
+          python -c "import nltk; nltk.download('all', quiet=True)"
 
-      - name: Run tests and save output
+      - name: Run tests
         run: |
           mkdir -p test-output
-          python -m pytest tests/ -v > test-output/pytest-output.txt || echo "Tests encountered an error"
-      
-      - name: Ensure test output exists
-        run: |
-          if [ ! -s test-output/pytest-output.txt ]; then echo "No output generated. Tests may have failed." > test-output/pytest-output.txt; fi
+          python -m pytest tests/ -v --capture=tee-sys
 
-      - name: Display test output
-        run: |
-          cat test-output/pytest-output.txt || echo "No pytest output available."
-
-      - name: Upload test results as artifacts
+      - name: Upload test results
         uses: actions/upload-artifact@v4
+        if: always()  # Upload even if tests fail
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: test-output/pytest-output.txt
+          path: |
+            test-output/
+            .pytest_cache/
+            pytest-logs.txt
           if-no-files-found: warn
 
   release:
-    if: always()
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -76,8 +84,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for proper versioning
 
-      - name: Download test results
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # Use latest LTS version
+
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -94,7 +109,8 @@ jobs:
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
           echo "## Test Results" >> release_notes.md
-          echo "See attached test results in artifacts" >> release_notes.md
+          echo "Test results summary:" >> release_notes.md
+          find artifacts -type f -exec cat {} \; >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1.37.0  # Updated to the latest stable version
+        uses: softprops/action-gh-release@v1  # Use latest stable version
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - issue178_build-test-failures
+      - main
 permissions:
   contents: write
   packages: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,103 +3,46 @@ name: Release
 on:
   push:
     branches:
-      - issue178_build-test-failures
-  workflow_run:
-    workflows: ["macos-build", "windows-build"]
-    types:
-      - completed
-
-permissions:
-  contents: write
-  packages: read
-  actions: read
+      - issue178_build-test-failures  # Specify your target branch
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create artifacts directory
-        run: mkdir -p artifacts/macos artifacts/windows
-
-      - name: Debug Event Info
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Event path: ${{ github.event_path }}"
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "Workflow run ID: ${{ github.event.workflow_run.id }}"
-            echo "Workflow name: ${{ github.event.workflow_run.name }}"
-            echo "Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
-          fi
-
       - name: Download macOS build artifacts
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'macos-build' }}
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download Windows build artifacts
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'windows-build' }}
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: List directory structure
-        run: |
-          echo "Full directory structure:"
-          find . -type f -not -path "./.git/*"
-          
-          echo "Contents of artifacts directory:"
-          ls -la artifacts/
-          ls -la artifacts/macos || echo "No macOS artifacts"
-          ls -la artifacts/windows || echo "No Windows artifacts"
-
-      - name: Create project ZIP
-        run: |
-          zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
 
       - name: Generate release notes
         run: |
           echo "## Automated Release" > release_notes.md
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
-          echo "Branch: ${{ github.ref_name }}" >> release_notes.md
-          echo "Event type: ${{ github.event_name }}" >> release_notes.md
           echo "## Downloads" >> release_notes.md
-          echo "- Saltify.zip: Complete project source code" >> release_notes.md
-          
-          if [ -d "artifacts/macos" ] && [ "$(ls -A artifacts/macos)" ]; then
-            echo "- macOS build included" >> release_notes.md
-          else
-            echo "Note: macOS build not available for this release" >> release_notes.md
-          fi
-          
-          if [ -d "artifacts/windows" ] && [ "$(ls -A artifacts/windows)" ]; then
-            echo "- Windows build included" >> release_notes.md
-          else
-            echo "Note: Windows build not available for this release" >> release_notes.md
-          fi
+          echo "- macOS and Windows build artifacts included." >> release_notes.md
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ github.run_number }}
-          name: Release ${{ github.run_number }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: false
-          files: |
-            artifacts/**/*
-            Saltify.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Authenticate GitHub CLI
+        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Create Release and Upload Assets
+        run: |
+          gh release create v${{ github.run_number }} \
+            -t "Release ${{ github.run_number }}" \
+            -F release_notes.md \
+            artifacts/macos \
+            artifacts/windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,17 @@
-name: Build, Test, and Release
+name: Build, Test, and Release on macOS and Windows
 
 on:
   push:
     branches:
-      - issue178_build-test-failures  # Changed back to your test branch
+      - issue178_build-test-failures
 
 jobs:
-  macos-build:
-    runs-on: macos-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    
     strategy:
       matrix:
+        os: [macos-latest, windows-latest]
         python-version: ['3.11', '3.12']
       fail-fast: false
     
@@ -17,151 +19,72 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-
-      - name: Debug Environment
+      - name: Log System Information
         run: |
           echo "Python version:"
           python --version
           echo "Pip version:"
           pip --version
-          echo "System info:"
-          sw_vers
-          echo "Brew info:"
-          brew --version
-
-      - name: Install system dependencies
-        run: |
-          brew update
-          brew install ffmpeg portaudio pkg-config
-          echo "Installed packages:"
-          brew list
-          echo "PortAudio location:"
-          brew list portaudio
-
-      - name: Set environment variables
-        run: |
-          echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I/usr/local/include" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig" >> $GITHUB_ENV
-          echo "Environment variables set:"
-          env | grep -E "LDFLAGS|CPPFLAGS|PKG_CONFIG_PATH"
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install -v -r requirements.txt
-          echo "Installed Python packages:"
-          pip list
-
-      - name: Install NLTK data
-        run: |
-          python -c "import nltk; nltk.download('all', quiet=True)"
-          echo "NLTK data directory:"
-          python -c "import nltk; print(nltk.data.path)"
-
-      - name: Run tests
-        run: |
-          mkdir -p test_output
-          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1 || true
-          echo "Test output directory contents:"
-          ls -la test_output/
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results-macos-${{ matrix.python-version }}
-          path: test_output
-          if-no-files-found: warn
-
-  windows-build:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.11', '3.12']
-      fail-fast: false
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+          echo "System Information:"
+          uname -a
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
-      - name: Debug Environment
-        shell: pwsh
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
         run: |
-          Write-Host "Python version:"
-          python --version
-          Write-Host "Pip version:"
-          pip --version
-          Write-Host "System info:"
-          systeminfo | select-string "OS"
+          brew update
+          brew install ffmpeg portaudio libomp cmake pkg-config
+          echo "Brew installed packages:"
+          brew list
 
-      - name: Install FFmpeg
-        shell: pwsh
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows'
         run: |
-          choco install ffmpeg -y
-          Write-Host "FFmpeg version:"
-          ffmpeg -version
+          choco install ffmpeg --verbose
+          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose
+          echo "Chocolatey installed packages:"
+          choco list --local-only
 
-      - name: Install PortAudio
-        shell: pwsh
+      - name: Install critical Python dependencies separately
         run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz" -OutFile "portaudio.tgz"
-          tar -xf portaudio.tgz
-          cd portaudio
-          mkdir build
-          cd build
-          cmake .. -G "Visual Studio 17 2022" -A x64
-          cmake --build . --config Release
-          cmake --install . --config Release
-          Write-Host "PortAudio installation completed"
-          dir "C:\Program Files\PortAudio"
-
-      - name: Install Python dependencies
-        shell: pwsh
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install -v -r requirements.txt
-          Write-Host "Installed Python packages:"
-          pip list
+          python -m pip install --upgrade pip
+          pip install torch==2.0.0 torchaudio==2.0.1 --verbose || echo "Torch/Torchaudio installation failed"
+          pip install -r requirements.txt --verbose || echo "Requirements installation failed"
 
       - name: Install NLTK data
-        shell: pwsh
         run: |
-          python -c "import nltk; nltk.download('all', quiet=True)"
-          python -c "import nltk; print(nltk.data.path)"
+          python -c "import nltk; nltk.download('all')"
 
-      - name: Run tests
-        shell: pwsh
+      - name: Run tests without output redirection
         run: |
-          mkdir test_output -ErrorAction SilentlyContinue
-          python -m pytest tests/ -v --junitxml=test_output/test-results.xml > test_output/pytest-output.txt 2>&1
-          Write-Host "Test output directory contents:"
-          dir test_output
+          mkdir -p test-output
+          python -m pytest tests/ -v || echo "Tests encountered an error"
+        continue-on-error: true
 
-      - name: Upload test results
+      - name: Ensure test output file exists
+        run: |
+          touch test-output/pytest-output.txt
+
+      - name: Display test output
+        run: |
+          cat test-output/pytest-output.txt || echo "No pytest output available."
+
+      - name: Store test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-windows-${{ matrix.python-version }}
-          path: test_output
+          name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: |
+            test-output/pytest-output.txt
           if-no-files-found: warn
 
-  create-release:
-    needs: [macos-build, windows-build]
+  release:
+    if: always()
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -170,35 +93,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download test results
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: test-results-*
           merge-multiple: true
 
-      - name: Debug artifacts
-        run: |
-          echo "Contents of artifacts directory:"
-          ls -R artifacts/
-          
       - name: Create project ZIP
         run: |
           zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
-          echo "Created ZIP file:"
-          ls -lh Saltify.zip
 
       - name: Generate release notes
         run: |
-          {
-            echo "## Automated Release"
-            echo "Build number: ${{ github.run_number }}"
-            echo "Commit: ${{ github.sha }}"
-            echo "## Test Results"
-            echo "Test results from macOS and Windows builds are attached."
-            echo "## Downloads"
-            echo "- Saltify.zip: Complete project source code"
-          } > release_notes.md
+          echo "## Automated Release" > release_notes.md
+          echo "Build number: ${{ github.run_number }}" >> release_notes.md
+          echo "Commit: ${{ github.sha }}" >> release_notes.md
+          echo "## Test Results" >> release_notes.md
+          echo "See attached test results in artifacts" >> release_notes.md
+          echo "## Downloads" >> release_notes.md
+          echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -209,7 +123,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            artifacts/**/*
+            artifacts/**
             Saltify.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,29 @@ on:
   push:
     branches:
       - issue178_build-test-failures  # Specify your target branch
+  workflow_run:
+    workflows: ["macos-build", "windows-build"]
+    types:
+      - completed
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Download macOS build artifacts
+        if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
 
       - name: Download Windows build artifacts
+        if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - issue178_build-test-failures
+
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:
@@ -13,9 +17,8 @@ permissions:
 
 jobs:
   release:
-    # Runs only if both `macos-build` and `windows-build` succeeded after a push to `issue178_build-test-failures`
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'issue178_build-test-failures' }}
-    
+    # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,22 +27,20 @@ jobs:
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install ffmpeg
-          brew install portaudio
-          brew install libomp
-          brew install cmake
+          brew update
+          brew install ffmpeg portaudio libomp cmake --verbose  # Use verbose for detailed logs
 
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install ffmpeg
-          choco install portaudio --source=https://community.chocolatey.org/api/v2/
+          choco install ffmpeg --verbose
+          choco install portaudio --source=https://community.chocolatey.org/api/v2/ --verbose
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch==2.0.0 torchaudio==2.0.1  # Adjust these versions if needed for compatibility
-          pip install -r requirements.txt
+          pip install torch==2.0.0 torchaudio==2.0.1 --verbose  # Verbose for detailed output
+          pip install -r requirements.txt --verbose
         continue-on-error: false
 
       - name: Install NLTK data
@@ -52,12 +50,13 @@ jobs:
       - name: Run tests with detailed output
         id: test
         run: |
-          python -m pytest tests/ -v --junitxml=test-results.xml --capture=tee-sys > pytest-output.txt 2>&1
+          mkdir -p test-output  # Ensure output folder exists
+          python -m pytest tests/ -v --junitxml=test-results.xml --capture=tee-sys > test-output/pytest-output.txt 2>&1
         continue-on-error: true
 
       - name: Display test output
         if: always()
-        run: cat pytest-output.txt
+        run: cat test-output/pytest-output.txt
         shell: bash
 
       - name: Store test results
@@ -67,7 +66,7 @@ jobs:
           name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             test-results.xml
-            pytest-output.txt
+            test-output/pytest-output.txt
           if-no-files-found: warn
 
   release:
@@ -90,7 +89,6 @@ jobs:
 
       - name: Create project ZIP
         run: |
-          # Create a ZIP of the entire project
           zip -r Saltify.zip . -x "*.git*" "*.pytest_cache*" "__pycache__/*" "*.pyc" "artifacts/*"
 
       - name: Generate release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,18 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # Uses latest version, will migrate to Node 20 automatically
 
       - name: Download macOS build artifacts
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
 
       - name: Download Windows build artifacts
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
@@ -45,7 +45,7 @@ jobs:
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1.1.0  # Updated to avoid Node.js deprecation warning
+        uses: softprops/action-gh-release@v1  # Latest stable version
         with:
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - issue178_build-test-failures
+      - issue178_build-test-failures  # Change to 'main' when deploying
 
 jobs:
   build:
@@ -24,22 +24,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install system dependencies
+      - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           brew install ffmpeg
           brew install portaudio
+          brew install libomp
+          brew install cmake
 
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
           choco install ffmpeg
-          choco install portaudio
+          choco install portaudio --source=https://community.chocolatey.org/api/v2/
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch torchaudio
+          pip install torch==2.0.0 torchaudio==2.0.1  # Adjust these versions if needed for compatibility
           pip install -r requirements.txt
         continue-on-error: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,27 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' || 
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create artifacts directory
+        run: mkdir -p artifacts/macos artifacts/windows
+
+      - name: Debug Event Info
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Event path: ${{ github.event_path }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "Workflow run ID: ${{ github.event.workflow_run.id }}"
+            echo "Workflow name: ${{ github.event.workflow_run.name }}"
+            echo "Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
+          fi
+
       - name: Download macOS build artifacts
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'macos-build' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
@@ -35,18 +45,24 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download Windows build artifacts
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow.name == 'windows-build' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: List artifacts (debug)
+      - name: List directory structure
         run: |
+          echo "Full directory structure:"
+          find . -type f -not -path "./.git/*"
+          
           echo "Contents of artifacts directory:"
-          ls -R artifacts/
+          ls -la artifacts/
+          ls -la artifacts/macos || echo "No macOS artifacts"
+          ls -la artifacts/windows || echo "No Windows artifacts"
 
       - name: Create project ZIP
         run: |
@@ -58,13 +74,20 @@ jobs:
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
           echo "Commit: ${{ github.sha }}" >> release_notes.md
           echo "Branch: ${{ github.ref_name }}" >> release_notes.md
+          echo "Event type: ${{ github.event_name }}" >> release_notes.md
           echo "## Downloads" >> release_notes.md
           echo "- Saltify.zip: Complete project source code" >> release_notes.md
-          if [ -d "artifacts/macos" ]; then
+          
+          if [ -d "artifacts/macos" ] && [ "$(ls -A artifacts/macos)" ]; then
             echo "- macOS build included" >> release_notes.md
+          else
+            echo "Note: macOS build not available for this release" >> release_notes.md
           fi
-          if [ -d "artifacts/windows" ]; then
+          
+          if [ -d "artifacts/windows" ] && [ "$(ls -A artifacts/windows)" ]; then
             echo "- Windows build included" >> release_notes.md
+          else
+            echo "Note: Windows build not available for this release" >> release_notes.md
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - issue178_build-test-failures
-
   workflow_run:
     workflows: ["macos-build", "windows-build"]
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   workflow_run:
     workflows: ["macos-build", "windows-build"]
+    branches:
+      - issue178_build-test-failures
     types:
       - completed
 
@@ -13,8 +15,7 @@ permissions:
 
 jobs:
   release:
-    # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}    
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Release on macOS and Windows
 on:
   push:
     branches:
-      - main
+      - issue178_build-test-failures
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release:
     # Ensures this job runs only if triggered by `push` *and* both `macos-build` and `windows-build` succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,62 +1,62 @@
 on:
-    push:
-      branches:
-        - main
-        - fix-exe
-        - testingv4artifact
-        - issue169_dependency
-        - issue178_build-test-failures
+  push:
+    branches:
+      - main
+      - fix-exe
+      - testingv4artifact
+      - issue169_dependency
+      - issue178_build-test-failures
 
 jobs:
-    build-windows:
-      runs-on: windows-latest
-  
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
-          with:
-            python-version: 3.11
+  build-windows:
+    runs-on: windows-latest
 
-        - name: Install Java
-          shell: powershell
-          run: |
-            if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
-              Write-Host "Java not found, installing JDK 11..."
-              choco install jdk11 -y
-            } else {
-              Write-Host "Java is already installed."
-            }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
 
-        - name: Install Specific Python Version
-          uses: actions/setup-python@v4
-          with:
-            python-version: 3.11.7
+      - name: Install Java
+        shell: powershell
+        run: |
+          if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
+            Write-Host "Java not found, installing JDK 11..."
+            choco install jdk11 -y
+          } else {
+            Write-Host "Java is already installed."
+          }
 
-        - name: Install NLTK
-          run: |
-            pip install nltk
-            python -m nltk.downloader punkt
-        
-        - name: Cache Python packages
-          uses: actions/cache@v3
-          with:
-            path: ~/.cache/pip
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-  
-        - run: pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
-        - run: pip uninstall -y typing
-        - run: pyinstaller --name Saltify --windowed --noconfirm --onedir -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
-  
-        - shell: cmd 
-          run: |
-            robocopy build_assets dist/Saltify /e /v 
-            mkdir dist\Saltify\_internal\lightning_fabric
-            robocopy dist/Saltify/_internal/lightning dist/Saltify/_internal/lightning_fabric /e /v
-            mkdir dist\Saltify\_internal\pattern\text\en\
-            move dist\Saltify\en-model.slp dist\Saltify\_internal\pattern\text\en\
-        
-        - uses: actions/upload-artifact@v4
-          if: always()
-          with:
-            name: SpeechTranscription_windows
-            path: dist/Saltify/*
+      - name: Install Specific Python Version
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.7
+
+      - name: Install NLTK
+        run: |
+          pip install nltk
+          python -m nltk.downloader punkt
+      
+      - name: Cache Python packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
+      - run: pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
+      - run: pip uninstall -y typing
+      - run: pyinstaller --name Saltify --windowed --noconfirm --onefile -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
+
+      - shell: cmd 
+        run: |
+          robocopy build_assets dist/Saltify /e /v 
+          mkdir dist\Saltify\_internal\lightning_fabric
+          robocopy dist/Saltify/_internal/lightning dist/Saltify/_internal/lightning_fabric /e /v
+          mkdir dist\Saltify\_internal\pattern\text\en\
+          move dist\Saltify\en-model.slp dist\Saltify\_internal\pattern\text\en\
+      
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: SpeechTranscription_windows
+          path: dist/Saltify.exe

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -5,6 +5,7 @@ on:
         - fix-exe
         - testingv4artifact
         - issue169_dependency
+        - issue178_build-test-failures
 
 jobs:
     build-windows:


### PR DESCRIPTION
Fixes #178

**What was changed?**

*Edited the file to omit the build steps since those are being taken care of by other build files now. The main focus of this file is to now create releases after pushes to the target (main) branch.*

**Why was it changed?**

*Builds were previously failing, now the focus of this file is to simply create releases on pushes to the main branch.*

**How was it changed?**

*Removed build components and focusing on creating releases only. Event triggers were also added to create when workflows for mac and windows builds complete. The updated file checks to ensure that previous workflows have properly completed before creating the release. Artifacts are also now managed by downloading based on the success of the mac and windows workflows.*

**Screenshots that show the changes (if applicable):**

