### PR TITLE
Issue_#195

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -14,9 +14,16 @@ import time
 WIDTH = 1340
 HEIGHT = 740
 SETTINGS_FILE = "user_settings.txt"
-LOCK_ICON = customtkinter.CTkImage(Image.open("images/locked_icon.png"), Image.open("images/locked_icon.png"), (30, 30))
-UNLOCK_ICON = customtkinter.CTkImage(Image.open("images/unlocked_icon.png"), Image.open("images/unlocked_icon.png"), (30, 30))
-CLEAR_ICON = customtkinter.CTkImage(Image.open("images/clear_icon.png"), Image.open("images/clear_icon.png"), (30, 30))
+
+def scale_image(image_path, size=(30, 30)):
+    #Makes sure resize the image
+    image = Image.open(image_path)
+    image = image.resize(size)
+    return customtkinter.CTkImage(light_image=image, dark_image=image, size=size)
+
+LOCK_ICON = scale_image("images/locked_icon.png", size=(30, 30))
+UNLOCK_ICON = scale_image("images/unlocked_icon.png", size =(30, 30))
+CLEAR_ICON = scale_image("images/clear_icon.png", size = (30, 30))
 
 def plotAudio(time, signal):
     '''Plots the waveform of audio'''
@@ -177,13 +184,13 @@ class audioMenu(CTkFrame):
 
         # Transcription Box Control and Frame
         self.transcriptionBoxFrame = CTkFrame(self)
-        self.transcriptionBoxFrame.grid(row=0, column=2, rowspan=5, columnspan=2, padx=10, pady=10, sticky=N+E+S+W)
+        self.transcriptionBoxFrame.grid(row=0, column=2, rowspan=5, columnspan=2,  padx=10, pady=10,sticky=N+E+S+W)
         self.transcriptionBoxLabel = CTkLabel(self.transcriptionBoxFrame, height=10, text="Transcription Box", font=("Arial", 18))
         self.transcriptionBoxLabel.grid(row=0, column=0, padx=5)
-        self.transcriptionBoxLockButton = createButton(master=self.transcriptionBoxFrame, text='', row=0, column=1, command=self.toggleTranscriptionBox, height=10, width=10, lock=False)
-        self.transcriptionBoxLockButton.configure(image=LOCK_ICON)
+        self.transcriptionBoxLockButton = createButton(master=self.transcriptionBoxFrame, text='', row=0, column=1, command=self.toggleTranscriptionBox, height =10, width=10, lock=False)
+        self.transcriptionBoxLockButton.configure(image=LOCK_ICON, width=30, height=30)
         self.transcriptionBoxClearButton = createButton(master=self.transcriptionBoxFrame, text='Clear Box?', row=0, column=2, command=self.clearTranscriptionBox, height=10, width=10, lock=False)
-        self.transcriptionBoxClearButton.configure(image=CLEAR_ICON)
+        self.transcriptionBoxClearButton.configure(image=CLEAR_ICON, width=30, height=30)
 
         self.transcriptionBox = CTkTextbox(self.transcriptionBoxFrame, width=350, height=500)
         self.transcriptionBox.grid(row=1, column=0, columnspan=3, padx=10, pady=10, sticky=N+E+S+W)
@@ -196,9 +203,9 @@ class audioMenu(CTkFrame):
         self.conventionBoxLabel = CTkLabel(self.conventionBoxFrame, height=10, text="Convention Box",  font=("Arial", 18))
         self.conventionBoxLabel.grid(row=0, column=0, padx=5)
         self.conventionBoxLockButton = createButton(master=self.conventionBoxFrame, text='', row=0, column=1, command=self.toggleGrammarBox, height=10, width=10, lock=False)
-        self.conventionBoxLockButton.configure(image=LOCK_ICON)
+        self.conventionBoxLockButton.configure(image=LOCK_ICON, width=30, height=30)
         self.conventionBoxClearButton = createButton(master=self.conventionBoxFrame, text='Clear Box?', row=0, column=2, command=self.clearGrammarBox,height=10, width=10, lock=False)
-        self.conventionBoxClearButton.configure(image=CLEAR_ICON)
+        self.conventionBoxClearButton.configure(image=CLEAR_ICON, width=30, height=30)
 
 
         self.conventionBox = CTkTextbox(self.conventionBoxFrame, width=350, height=500)


### PR DESCRIPTION
Fixes #195 

**What was changed?**
*In the GUI, I changed the white background of the images to now be transparent, making the background be the same color of the lock/unlock/clear buttons.* 

**Why was it changed?**
*The previous look had a unappealing look when clicking on the lock/unlock/clear buttons. Now they are clean and isn't a visual clutter.*

**Here, describe the issue that you are fixing with this code, and why your code fixes it.**
*I created a function called scale_image for any new image and current images to always be scaled to 30x30 pixels (without the function, any image can be scaled to any number). The added configurations to the buttons makes the white background disappear because customtkinter.CTkImage, and before the changes it might have been because the image was loaded incorrectly.*

**How was it changed?**
*In GUI.py, a new function name scale_image was created, configurations of the transcriptions and conventions were changed. Adding an extra configurations of the pixel ratio made the backgrounds of the lock/unlock/clear images to disappear and look clean visually.*

**Screenshots that show the changes (if applicable):**
*Before* 
<img width="671" alt="Screenshot 2025-01-25 224731" src="https://github.com/user-attachments/assets/137ecb34-7771-494e-8a5f-6c97afee9f35" />
*After*
<img width="665" alt="issue195" src="https://github.com/user-attachments/assets/495037e7-d0f5-46ac-b7d6-85d87428802a" />


