### PR TITLE
Issue 202: Add synchronized timestamps to transcription lines

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 import time
 import webbrowser
 import traceback
+import re
 
 WIDTH = 1340
 HEIGHT = 740
@@ -551,9 +552,15 @@ class audioMenu(CTkFrame):
                                                 initialfile=self.exporter.getDefaultFilename() + ".docx")
         if downloadFile:
             text = self.getTranscriptionText()
+            
+            text_without_timestamps = re.sub(r'\[\d+:\d+\] ', '', text)
+            
             if self.grammarCheckPerformed:
-                text = self.getGrammarText()
-            self.exporter.exportToWord(text, downloadFile.name)
+                grammar_text = self.getGrammarText()
+                grammar_text_without_timestamps = re.sub(r'\[\d+:\d+\] ', '', grammar_text)
+                self.exporter.exportToWord(grammar_text_without_timestamps, downloadFile.name)
+            else:
+                self.exporter.exportToWord(text_without_timestamps, downloadFile.name)
 
     @global_error_handler
     def grammarCheck(self):

--- a/GUI.py
+++ b/GUI.py
@@ -408,41 +408,42 @@ class audioMenu(CTkFrame):
     def labelSpeakers(self):
         popup = CTkToplevel(self)
         popup.title("Label Speakers")
-        popup.geometry("600x400")  # Adjust size as needed
+        popup.geometry("600x400")
 
         scrollable_frame = CTkScrollableFrame(popup)
         scrollable_frame.pack(fill='both', expand=True)
 
-        # Initial split of the transcription text (used to generate checkboxes only)
         initial_segments = self.getTranscriptionText().split('\n')
-
-        # Store checkboxes, associated with the index in the original text
         self.segment_selections = []
         for idx, segment in enumerate(initial_segments):
-            if segment.strip():  # Ignore empty lines
+            if segment.strip():
                 var = IntVar()
                 chk = CTkCheckBox(scrollable_frame, text=segment, variable=var)
                 chk.pack(anchor='w', padx=5, pady=2)
                 self.segment_selections.append((var, idx))
 
         def apply_labels(speaker):
-            # Fetch the current state of the transcription text
             current_text = self.getTranscriptionText()
             current_segments = current_text.split('\n')
 
             for var, idx in self.segment_selections:
                 if var.get() and not current_segments[idx].startswith(f"{speaker}:"):
-                    # Append the speaker label only if it's not already labeled
-                    current_segments[idx] = f"{speaker}: {current_segments[idx]}"
-                    var.set(0)  # Optionally reset the checkbox after labeling
+                    line = current_segments[idx]
+                    # Check for existing timestamp at the beginning of the line
+                    match = re.match(r'^\[(\d+:\d+)\]\s*(.*)', line)
+                    if match:
+                        timestamp = match.group(1)
+                        rest = match.group(2)
+                        current_segments[idx] = f"[{timestamp}] {speaker}: {rest}"
+                    else:
+                        current_segments[idx] = f"{speaker}: {line}"
+                    var.set(0)  # Reset the checkbox
 
-            # Update the transcriptionBox with the modified text
             new_transcription_text = "\n".join(current_segments)
             self.transcriptionBox.delete("0.0", "end")
             self.transcriptionBox.insert("0.0", new_transcription_text)
             unlockItem(self.applyAliasesButton)
 
-        # Buttons for applying speaker labels
         CTkButton(popup, text="Label as Speaker 1", command=lambda: apply_labels("Speaker 1")).pack(side='left', padx=10, pady=10)
         CTkButton(popup, text="Label as Speaker 2", command=lambda: apply_labels("Speaker 2")).pack(side='right', padx=10, pady=10)
 


### PR DESCRIPTION
Fixes #202 

**What was changed?**
The changes were made to the transcription functionality of the application, specifically in the diarizationAndTranscription.py file. The goal was to integrate synchronized timestamps into the transcribed text displayed in the transcription box.

**Why was it changed?**
The change was made to improve the readability and usability of the transcribed text. Previously, the transcription did not include timestamps, making it difficult for users to track when specific parts of the transcription occurred in the audio. By adding synchronized timestamps, users can now easily correlate the transcribed text with the corresponding time in the audio.

**How was it changed?**
In diarizationAndTranscription.py, I added a new function formatTranscriptionWithTimestamps to format the transcription text with timestamps and modified the transcribe and diarizeAndTranscribe functions to include timestamps in the transcription output.

**Screenshots that show the changes (if applicable):**
<img width="1337" alt="Screenshot 2025-02-16 at 3 28 13 PM" src="https://github.com/user-attachments/assets/f5eb3196-2687-4f4f-a3f0-b84b9219a60e" />
