### PR TITLE
Issue 205 - Creating an Executable for macOS

### DIFF
--- a/.github/workflows/macOS_exec.sh
+++ b/.github/workflows/macOS_exec.sh
@@ -1,0 +1,19 @@
+pyinstaller --onefile --noconsole \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/images:images" \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/build_assets/en-model.slp:build_assets" \
+    --add-data="CTkXYFrame:CTkXYFrame" \
+    --add-binary="/opt/homebrew/opt/portaudio/lib/libportaudio.2.dylib:." \
+    --add-binary="/opt/homebrew/bin/ffmpeg:." \
+    --add-binary="/opt/homebrew/bin/ffprobe:." \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages:site-packages" \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/whisper:whisper" \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/filelock:filelock" \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/typing_extensions:typing_extensions" \
+    --add-data="/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/lightning_fabric/version.info:lightning_fabric" \
+    --hidden-import="lightning_fabric" \
+    --hidden-import="lightning_fabric.version" \
+    --hidden-import="torch" \
+    --hidden-import="torchvision" \
+    --hidden-import="typing_extensions" \
+    --collect-all lightning_fabric \
+    GUI.py


### PR DESCRIPTION
Fixes #205 

**What was changed?**

*I added a new bash script to the workflows subdirectory which includes a script that should locally produce a working executable file.*

**Why was it changed?**

*We need to have a script that creates a working executable which can be provided on our releases so that out clients and other SLPs can use the app since they might not be familiar with a more complicated setup process.*

**How was it changed?**

*I added a onefile pyinstaller command that should install the necessary dependencies in order to produce a working executable for the application.*

**Screenshots that show the changes (if applicable):**

