### PR TITLE
Locking Upload and Record Audio Buttons

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -93,6 +93,9 @@ class mainGUI(CTk):
 
             self.changeAudioWindow(self.currentAudioNum)
             self.currentAudioNum += 1
+            # Enable the Upload and Record buttons for the new session
+            unlockItem(self.audioMenuList[-1].uploadButton)
+            unlockItem(self.audioMenuList[-1].recordButton)
 
     @global_error_handler
     def changeAudioWindow(self, num):
@@ -126,8 +129,8 @@ class mainGUI(CTk):
         Help Guide:
         
         - New Audio: Create a new audio session.
-        - Upload: Upload an audio file.
-        - Record: Record a new audio file.
+        - Upload: Upload an audio file. (Disabled after first upload to prevent modifications, but enabled again after starting a new session)
+        - Record: Record a new audio file. (Disabled after first recording to prevent modifications, but enabled again after starting a new session)
         - <<: Rewind the audio by 5 seconds.
         - ⏯: Play and Pause the audio.
         - >>: Fast forward the audio by 5 seconds.
@@ -143,7 +146,6 @@ class mainGUI(CTk):
         - Lock/Unlock: Lock or unlock the transcription or convention box in order to manually edit the transcribed/convention text.
         """
 
-        # Instead of a scrollable frame, use a regular frame
         helpLabel = CTkLabel(popup, text=helpText, justify=LEFT, font=("Arial", 12), wraplength=400)
         helpLabel.pack(padx=10, pady=10)
 
@@ -603,7 +605,6 @@ class audioMenu(CTkFrame):
         if filename:
             print("File uploaded: ", filename)
             unlockItem(self.playPauseButton)
-            unlockItem(self.playPauseButton)
             unlockItem(self.transcribeButton)
             unlockItem(self.downloadAudioButton)
             time, signal = self.audio.upload(filename)
@@ -612,7 +613,9 @@ class audioMenu(CTkFrame):
             if self.audio and self.audio.filePath:
                 self.timelineSlider.configure(from_=0, to=self.audioLength, state="normal")
                 print(f"Slider enabled with range: 0 to {self.audioLength} seconds.")
-
+            # Disable the Upload and Record buttons
+            lockItem(self.uploadButton)
+            lockItem(self.recordButton)
 
     @global_error_handler
     def recordAudio(self):
@@ -627,6 +630,9 @@ class audioMenu(CTkFrame):
             unlockItem(self.downloadAudioButton)
             filename, time, signal = self.audio.stop()
             plotAudio(time, signal)
+            # Disable the Upload and Record buttons
+            lockItem(self.uploadButton)
+            lockItem(self.recordButton)
 
     @global_error_handler
     def transcribe(self):


### PR DESCRIPTION
Fixes #212 

**What was changed?**

*I made edits to the GUI file in order to ensure that the upload and record audio buttons are disabled after the initial upload/record and are only enabled again if a new audio session is created. I also updated the help guide to include this information*

**Why was it changed?**

*The purpose for these changes is to ensure that there won't be any inconsistencies within audio sessions. My code works to lock and unlock the buttons accordingly.*

**How was it changed?**

*I added lockItem and unlockItem statements to the recordAudio and uploadAudio functions as well as unlockItem statements to new_audio function in order to lock and unlock the Upload Audio and Record Audio buttons, such that they will only be unlocked at the start of a new audio session and locked as soon as a file is either uploaded or recorded. I also added new statements to the text within the help guide in order to convey this information.*

before:
<img width="1333" alt="before" src="https://github.com/user-attachments/assets/64237d0e-b4c8-4e27-a764-79f976da78f4" />
after:
<img width="1334" alt="after (2)" src="https://github.com/user-attachments/assets/32298966-1511-4a0b-9a3d-6a5b45cc98ef" />
<img width="1333" alt="after" src="https://github.com/user-attachments/assets/f05229a1-27c8-41b5-b2e7-830f8249bf04" />

