### PR TITLE
Relative Paths for Cross-Platform Execution

### DIFF
--- a/scripts/macOS_exec.sh
+++ b/scripts/macOS_exec.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-
 BASE_DIR="$SCRIPT_DIR/.."
 
-pyinstaller --onefile --noconsole \
+VENV_NAME=$(basename "$VIRTUAL_ENV")
+
+pyinstaller --onefile --windowed \
   --add-data "$BASE_DIR/images:images" \
   --add-data "$BASE_DIR/build_assets/en-model.slp:pattern/text/en" \
   --add-data "$BASE_DIR/CTkXYFrame:CTkXYFrame" \
   --add-binary "/opt/homebrew/opt/portaudio/lib/libportaudio.2.dylib:." \
   --add-binary "/opt/homebrew/bin/ffmpeg:." \
   --add-binary "/opt/homebrew/bin/ffprobe:." \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/lightning_fabric:lightning_fabric" \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/whisper:whisper" \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/filelock:filelock" \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/lightning_fabric/version.info:lightning_fabric" \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/pytorch_lightning:torchlightning" \
-  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/pyannote:pyannote" \
+  --add-data "$BASE_DIR/$VENV_NAME/lib/python3.11/site-packages/lightning_fabric:lightning_fabric" \
+  --add-data "$BASE_DIR/$VENV_NAME/lib/python3.11/site-packages/whisper:whisper" \
+  --add-data "$BASE_DIR/$VENV_NAME/lib/python3.11/site-packages/filelock:filelock" \
+  --add-data "$BASE_DIR/$VENV_NAME/lib/python3.11/site-packages/pytorch_lightning:torchlightning" \
+  --add-data "$BASE_DIR/$VENV_NAME/lib/python3.11/site-packages/pyannote:pyannote" \
   --hidden-import "lightning_fabric" \
   --hidden-import "torch" \
   --hidden-import "torchvision" \

--- a/scripts/macOS_exec.sh
+++ b/scripts/macOS_exec.sh
@@ -1,20 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+BASE_DIR="$SCRIPT_DIR/.."
+
 pyinstaller --onefile --noconsole \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/images:images" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/build_assets/en-model.slp:pattern/text/en" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/CTkXYFrame:CTkXYFrame" \
+  --add-data "$BASE_DIR/images:images" \
+  --add-data "$BASE_DIR/build_assets/en-model.slp:pattern/text/en" \
+  --add-data "$BASE_DIR/CTkXYFrame:CTkXYFrame" \
   --add-binary "/opt/homebrew/opt/portaudio/lib/libportaudio.2.dylib:." \
   --add-binary "/opt/homebrew/bin/ffmpeg:." \
   --add-binary "/opt/homebrew/bin/ffprobe:." \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/lightning_fabric:lightning_fabric" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/whisper:whisper" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/filelock:filelock" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/lightning_fabric/version.info:lightning_fabric" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/pytorch_lightning:torchlightning" \
-  --add-data "/Users/ksp/Desktop/temp/SpeechTranscription/myenv/lib/python3.11/site-packages/pyannote:pyannote" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/lightning_fabric:lightning_fabric" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/whisper:whisper" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/filelock:filelock" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/lightning_fabric/version.info:lightning_fabric" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/pytorch_lightning:torchlightning" \
+  --add-data "$BASE_DIR/myenv/lib/python3.11/site-packages/pyannote:pyannote" \
   --hidden-import "lightning_fabric" \
   --hidden-import "torch" \
   --hidden-import "torchvision" \
   --hidden-import "pytorch_lightning" \
   --hidden-import "pyannote.audio" \
-  /Users/ksp/Desktop/temp/SpeechTranscription/GUI.py
-  
+  "$BASE_DIR/GUI.py"

--- a/scripts/macOS_exec.sh
+++ b/scripts/macOS_exec.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_DIR="$SCRIPT_DIR/.."
 
 VENV_NAME=$(basename "$VIRTUAL_ENV")
 
-pyinstaller --onefile --windowed \
+pyinstaller --onefile --noconsole \
   --add-data "$BASE_DIR/images:images" \
   --add-data "$BASE_DIR/build_assets/en-model.slp:pattern/text/en" \
   --add-data "$BASE_DIR/CTkXYFrame:CTkXYFrame" \


### PR DESCRIPTION
Fixes #214

**What was changed?**

I modified the macOS_exec.sh script. 

**Why was it changed?**

The script used absolute paths, making it non-portable and dependent on specific directory structures. By making the changes, the script is now portable by using relative paths.

**How was it changed?**

I replaced absolute paths with relative paths based on the script's location and modified the pyinstaller command to use relative paths for --add-data and --add-binary options.

