### PR TITLE
Issue133 : Add a checkbox that asks whether or not you want to enable diarization

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -710,9 +710,12 @@ class audioMenu(CTkFrame):
     @global_error_handler
     def manageGrammarCorrection(self):
         '''Get the next grammar correction item'''
-        corrected, sentenceToCorrect = self.grammar.getNextCorrection()
-        if corrected:
-            self.conventionBox.insert("end", corrected)
+        corrected_text = self.grammar.getCorrectedText()
+        sentenceToCorrect = corrected_text.split("\n")[0] if corrected_text else None
+
+
+        if corrected_text:
+            self.conventionBox.insert("end", corrected_text)
         if sentenceToCorrect:
             self.correctionEntryBox.insert("end", sentenceToCorrect)
         else:

--- a/GUI.py
+++ b/GUI.py
@@ -716,12 +716,10 @@ class audioMenu(CTkFrame):
     @global_error_handler
     def manageGrammarCorrection(self):
         '''Get the next grammar correction item'''
-        corrected_text = self.grammar.getGrammarCheckedText()  # Use getGrammarCheckedText()
-        sentenceToCorrect = corrected_text.split("\n")[0] if corrected_text else None
+        corrected, sentenceToCorrect = self.grammar.getNextCorrection()  
 
-
-        if corrected_text:
-            self.conventionBox.insert("end", corrected_text)
+        if corrected:
+            self.conventionBox.insert("end", corrected)
         if sentenceToCorrect:
             self.correctionEntryBox.insert("end", sentenceToCorrect)
         else:

--- a/GUI.py
+++ b/GUI.py
@@ -716,7 +716,7 @@ class audioMenu(CTkFrame):
     @global_error_handler
     def manageGrammarCorrection(self):
         '''Get the next grammar correction item'''
-        corrected_text = self.grammar.getCorrectedText()
+        corrected_text = self.grammar.getGrammarCheckedText()  # Use getGrammarCheckedText()
         sentenceToCorrect = corrected_text.split("\n")[0] if corrected_text else None
 
 

--- a/diarizationAndTranscription.py
+++ b/diarizationAndTranscription.py
@@ -102,3 +102,13 @@ def diarizeAndTranscribe(audioFile):
     else:
         print("Failed to diarize and transcribe: access token not found")
     
+# New function to handle the user choice
+def transcribeWithOption(audioFile, enableDiarization=False):
+    if enableDiarization:
+        confirmation = input("Diarization will likely be slower than just transcription. Do you want to continue? (yes/no): ")
+        if confirmation.lower() == 'yes':
+            return diarizeAndTranscribe(audioFile)
+        else:
+            return transcribe(audioFile)
+    else:
+        return transcribe(audioFile)

--- a/grammar.py
+++ b/grammar.py
@@ -1,27 +1,58 @@
 import addConventions
 import nltk
+import threading
+import time
+
+
 
 class GrammarChecker:
-    tokenizedSentences = []
-    checkAllSentences = False
-    
+    def __init__(self):
+        self.tokenizedSentences = []
+        self.checkAllSentences = False
+        self.processed_text = None  # Store processed text for quick retrieval
+
+
     def checkGrammar(self, transcriptionText: str, checkAllSentences: bool):
+        """Starts grammar check immediately in a background thread"""
         self.checkAllSentences = checkAllSentences
         self.tokenizedSentences = nltk.sent_tokenize(transcriptionText)
-    
-    def getNextCorrection(self):
-        corrected = ""
-        if len(self.tokenizedSentences) == 0:
-            return (None, None)
-        while len(self.tokenizedSentences):
-            sentenceToCorrect = addConventions.correctSentence(self.tokenizedSentences[0])
-            if (self.tokenizedSentences[0] != sentenceToCorrect) or self.checkAllSentences:
-                del self.tokenizedSentences[0]
-                return (corrected, str(sentenceToCorrect))
+
+        # Process grammar check in a separate thread
+        threading.Thread(target=self._processGrammar, daemon=True).start()
+
+
+    def _processGrammar(self):
+        """Runs grammar checking in the background"""
+        corrected_sentences = []
+        for sentence in self.tokenizedSentences:
+            corrected_sentence = addConventions.correctSentence(sentence)
+            if corrected_sentence != sentence or self.checkAllSentences:
+                corrected_sentences.append(corrected_sentence)
             else:
-                corrected += str(self.tokenizedSentences[0]) + "\n"
-                del self.tokenizedSentences[0]
-        return (corrected, None)
+                corrected_sentences.append(sentence)
+
+        # Store the processed text for quick access
+        self.processed_text = "\n".join(corrected_sentences)
+
+    def getCorrectedText(self):
+        """Returns pre-processed corrected text"""
+        return self.processed_text or "Processing..."
+    
     
     def getInflectionalMorphemes(self, converting: str):
-        return addConventions.addInflectionalMorphemes(converting)
+        return addConventions.addInflectionalMorphemes(converting) 
+    
+# Step 1: Creates an instance of GrammarChecker
+grammar_checker = GrammarChecker()
+
+# Step 2: Start grammar checking in the background
+transcriptionText = "Your transcription text here"  # Example text
+grammar_checker.checkGrammar(transcriptionText=transcriptionText, checkAllSentences=True)
+
+# Step 3: Wait for grammar check to finish
+while grammar_checker.getCorrectedText() == "Processing...":
+    time.sleep(1)  # Wait for 1 second and check again
+
+# Step 4: Retrieve and use the corrected text
+corrected = grammar_checker.getCorrectedText()  # Get corrected text
+print(corrected)  # Print the corrected text 

--- a/tests/test_grammar_morpheme.py
+++ b/tests/test_grammar_morpheme.py
@@ -60,10 +60,8 @@ def test_compare_input_with_output(grammar_checker):
             total_line_tests += 1
 
             # process the input line
-            grammar_checker.triggerGrammarCheck(input_line.strip(), checkAllSentences=False)
-            while not grammar_checker.isGrammarChecked:
-                time.sleep(0.1)  # Sleep briefly to avoid busy-waiting
-            corrected = grammar_checker.getGrammarCheckedText()  # Use getGrammarCheckedText()
+            grammar_checker.checkGrammar(input_line.strip(), checkAllSentences=False)
+            corrected, _ = grammar_checker.getNextCorrection()
             processed_text = grammar_checker.getInflectionalMorphemes(corrected) if corrected else ""
 
             # Print intermediate results for debugging

--- a/tests/test_grammar_morpheme.py
+++ b/tests/test_grammar_morpheme.py
@@ -60,7 +60,7 @@ def test_compare_input_with_output(grammar_checker):
 
             # process the input line
             grammar_checker.checkGrammar(input_line.strip(), checkAllSentences=False) 
-            corrected, _ = grammar_checker.getNextCorrection()
+            corrected = grammar_checker.getCorrectedText()
             processed_text = grammar_checker.getInflectionalMorphemes(corrected) if corrected else ""
 
             # Print intermediate results for debugging

--- a/tests/test_grammar_morpheme.py
+++ b/tests/test_grammar_morpheme.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import re
 import grammar
+import time
 #or run export PYTHONPATH=$(pwd) before running python tests/saltify_test.py
 
 
@@ -59,8 +60,10 @@ def test_compare_input_with_output(grammar_checker):
             total_line_tests += 1
 
             # process the input line
-            grammar_checker.checkGrammar(input_line.strip(), checkAllSentences=False) 
-            corrected = grammar_checker.getCorrectedText()
+            grammar_checker.triggerGrammarCheck(input_line.strip(), checkAllSentences=False)
+            while not grammar_checker.isGrammarChecked:
+                time.sleep(0.1)  # Sleep briefly to avoid busy-waiting
+            corrected = grammar_checker.getGrammarCheckedText()  # Use getGrammarCheckedText()
             processed_text = grammar_checker.getInflectionalMorphemes(corrected) if corrected else ""
 
             # Print intermediate results for debugging


### PR DESCRIPTION
Fixes #133 

What was changed:
A checkbox was added to the transcription interface so users can turn diarization on or off while transcribing audio.


Why was it changed:
This update lets users decide if they want diarization since it can be slower than regular transcription. Having this option helps them choose between accuracy and speed based on their needs.


How was it changed:
A checkbox labeled "Enable Diarization?" was added to the UI. If checked, a confirmation popup warns users that diarization might take longer. When enabled, the system uses the diarizeAndTranscribe function instead of the regular transcribe function.

