### PR TITLE
Issue 227 - New Session Flow

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -10,19 +10,29 @@ import sys
 
 class mainGUI(CTk):
     @global_error_handler
-    def new_audio(self):
-        dialog = CTkInputDialog(text="Enter Name of Session", title="New Audio")
-        session_name = dialog.get_input().strip()
-        if session_name:
-            self.audioMenuList.append(audioMenu(self))
-            newButton = createButton(self.userFrame.audioTabs, session_name, len(self.audioButtonList), 0,
-                                   lambda x=self.currentAudioNum: self.changeAudioWindow(x),
-                                   width=self.userFrame.audioTabs.cget("width"), lock=False)
-            self.audioButtonList.append(newButton)
-            self.changeAudioWindow(self.currentAudioNum)
-            self.currentAudioNum += 1
-            unlockItem(self.audioMenuList[-1].uploadButton)
-            unlockItem(self.audioMenuList[-1].recordButton)
+    def new_session(self):
+        '''Automatically generates a new session with a unique name and navigates to the main page.'''
+        from datetime import datetime
+
+        # Generate session name in the format: "Session <Number> - <Date> <Time>"
+        session_number = self.currentAudioNum + 1
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        session_name = f"Session {session_number} - {current_time}"
+
+        # Create a new audio session
+        self.audioMenuList.append(audioMenu(self))
+        newButton = createButton(self.userFrame.audioTabs, session_name, len(self.audioButtonList), 0,
+                                 lambda x=self.currentAudioNum: self.changeAudioWindow(x),
+                                 width=self.userFrame.audioTabs.cget("width"), lock=False)
+        self.audioButtonList.append(newButton)
+
+        # Navigate directly to the new session
+        self.changeAudioWindow(self.currentAudioNum)
+        self.currentAudioNum += 1
+
+        # Enable the Upload and Record buttons for the new session
+        unlockItem(self.audioMenuList[-1].uploadButton)
+        unlockItem(self.audioMenuList[-1].recordButton)
 
     @global_error_handler
     def changeAudioWindow(self, num):
@@ -103,8 +113,9 @@ class mainGUI(CTk):
         self.userFrame = userMenu(master=self)
         self.userFrame.grid(row=0, column=0, padx=1, sticky=NW)
 
-        self.newAudioButton = createButton(self.userFrame, "New Audio", 1, 0, self.new_audio, 
-                                         height=60, columnspan=2, lock=False)
+        # Replace "New Audio" button with "New Session" button
+        self.newSessionButton = createButton(self.userFrame, "New Session", 1, 0, self.new_session, 
+                                             height=60, columnspan=2, lock=False)
         self.audioFrame = CTkFrame(self)
         
         # Add Help Button


### PR DESCRIPTION
Fixes #227 

**What was changed?**

*I updated the initial audio session flow by removing the existing "New Audio" button, and the subsequent pop-up window to name the session, with a "New Session" button that automatically directs the user to the main application page when clicked.*

**Why was it changed?**

*These changes were made to simplify the initial set-up after the app has launched and to organize the session naming process.*

**How was it changed?**

*In the GUI file, I added a new_session method to the mainGUI class which generates a new session, titled in a Session <Number> - <Date> <Time> format. I also removed the pop-up dialog box which was previously used to name the session.*

<img width="1440" alt="after2-2" src="https://github.com/user-attachments/assets/2dc03f18-db8b-485e-bd64-05aa8bccd309" />
<img width="1440" alt="after2" src="https://github.com/user-attachments/assets/244e4273-ebd8-461f-8c44-b7282d5fd750" />


