### PR TITLE
Add speaker label colors in speaker label box

### DIFF
--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -371,13 +371,30 @@ class audioMenu(CTkFrame):
         for idx, segment in enumerate(initial_segments):
             if segment.strip():
                 var = IntVar()
-                chk = CTkCheckBox(scrollable_frame, text=segment, variable=var)
-                chk.pack(anchor='w', padx=5, pady=2)
+                
+                # Create a frame for each segment to allow for color coding
+                segment_frame = CTkFrame(scrollable_frame)
+                segment_frame.pack(fill='x', padx=5, pady=2)
+                
+                # Check if the segment already has a speaker label
+                speaker_match = re.match(r'^(\[?\d+:\d+\]?)?\s*(Speaker \d+):', segment)
+                if speaker_match:
+                    speaker = speaker_match.group(2)
+                    color = SPEAKER_COLORS.get(speaker, "#FFFFFF")  # Default to white if speaker not found
+                    segment_label = CTkLabel(segment_frame, text=segment, text_color=color)
+                else:
+                    segment_label = CTkLabel(segment_frame, text=segment)
+                
+                chk = CTkCheckBox(segment_frame, text="", variable=var, width=20)
+                chk.pack(side='left', padx=(0, 5))
+                segment_label.pack(side='left', fill='x', expand=True)
+                
                 self.segment_selections.append((var, idx))
 
         def apply_labels(speaker):
             current_text = self.getTranscriptionText()
             current_segments = current_text.split('\n')
+            color = SPEAKER_COLORS.get(speaker, "#FFFFFF")  # Get color for the speaker
 
             for var, idx in self.segment_selections:
                 if var.get() and not current_segments[idx].startswith(f"{speaker}:"):
@@ -391,6 +408,13 @@ class audioMenu(CTkFrame):
                         current_segments[idx] = f"{speaker}: {line}"
                     var.set(0)
 
+                    # Update the displayed text with color
+                    for widget in scrollable_frame.winfo_children():
+                        if isinstance(widget, CTkFrame):
+                            for child in widget.winfo_children():
+                                if isinstance(child, CTkLabel) and child.cget("text") == line:
+                                    child.configure(text=current_segments[idx], text_color=color)
+
             new_transcription_text = "\n".join(current_segments)
             self.transcriptionBox.configure(state="normal")
             self.transcriptionBox.delete("1.0", "end")
@@ -403,9 +427,15 @@ class audioMenu(CTkFrame):
 
         speaker1_alias = self.speaker_aliases.get("Speaker 1", "Speaker 1")
         speaker2_alias = self.speaker_aliases.get("Speaker 2", "Speaker 2")
-        CTkButton(button_frame, text=f"Label as {speaker1_alias}", command=lambda: apply_labels(speaker1_alias), fg_color="#029CFF").pack(side="left", padx=10)
-        CTkButton(button_frame, text=f"Label as {speaker2_alias}", command=lambda: apply_labels(speaker2_alias), fg_color="#FF5733").pack(side="right", padx=10)
-
+        
+        # Use speaker colors for the buttons
+        CTkButton(button_frame, text=f"Label as {speaker1_alias}", 
+                command=lambda: apply_labels("Speaker 1"), 
+                fg_color=SPEAKER_COLORS["Speaker 1"]).pack(side="left", padx=10)
+        CTkButton(button_frame, text=f"Label as {speaker2_alias}", 
+                command=lambda: apply_labels("Speaker 2"), 
+                fg_color=SPEAKER_COLORS["Speaker 2"]).pack(side="right", padx=10)
+    
     @global_error_handler
     def customizeSpeakerAliases(self):
         popup = CTkToplevel(self)

--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -372,22 +372,20 @@ class audioMenu(CTkFrame):
             if segment.strip():
                 var = IntVar()
                 
-                # Create a frame for each segment to allow for color coding
                 segment_frame = CTkFrame(scrollable_frame)
                 segment_frame.pack(fill='x', padx=5, pady=2)
                 
-                # Check if the segment already has a speaker label
                 speaker_match = re.match(r'^(\[?\d+:\d+\]?)?\s*(Speaker \d+):', segment)
                 if speaker_match:
                     speaker = speaker_match.group(2)
-                    color = SPEAKER_COLORS.get(speaker, "#FFFFFF")  # Default to white if speaker not found
-                    segment_label = CTkLabel(segment_frame, text=segment, text_color=color)
+                    color = SPEAKER_COLORS.get(speaker, "#FFFFFF") 
+                    segment_label = CTkLabel(segment_frame, text=segment, text_color=color, anchor='w') 
                 else:
-                    segment_label = CTkLabel(segment_frame, text=segment)
+                    segment_label = CTkLabel(segment_frame, text=segment, anchor='w') 
                 
                 chk = CTkCheckBox(segment_frame, text="", variable=var, width=20)
                 chk.pack(side='left', padx=(0, 5))
-                segment_label.pack(side='left', fill='x', expand=True)
+                segment_label.pack(side='left', fill='x', expand=True, anchor='w')  
                 
                 self.segment_selections.append((var, idx))
 


### PR DESCRIPTION
Fixes #241 

**What was changed?**

Added color-coding to speaker labels and buttons in the labeling window to match the main transcription box's styling.

**Why was it changed?**

To make speakers visually distinguishable when selecting multiple lines and maintain consistency with the main interface.

**How was it changed?**

By modifying the label display to use colored text and buttons, while keeping all existing functionality intact. I only made changes in audio_menu.py file.

**Screenshots that show the changes (if applicable):**
<img width="1082" alt="Screenshot 2025-04-25 at 11 39 04 PM" src="https://github.com/user-attachments/assets/33f55ff8-0317-4270-8639-4da03ce1ece6" />

