### PR TITLE
Fix Windows .exe crash by adding missing data to PyInstaller build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ For details on setting up the development environment, please refer to the [DEVE
 <br />
 <br />
 
+## Known Issues and Packaging Notes
+
+When packaging this project into a standalone `.exe` (e.g., with PyInstaller), crashes may occur due to missing dependencies or data files.
+
+- **Pattern models**: `pattern` requires its `en-model.slp` file at runtime. Ensure it is included in the PyInstaller build using `--venv/Lib/site-packages/pattern/text;pattern/text"`.
+- **Python DLL errors**: If a `python311.dll` (or similar) error occurs, ensure your Python installation matches the environment used to build the project.
+- **lightning_fabric**: Must be explicitly listed in `requirements.txt` as it is required by `pyannote.audio`.
+
+### Development Notes
+- The app runs correctly when launched via `python GUI.py` in a configured environment.
+- Crashes appear only after packaging into an `.exe`.
+- To investigate `.exe` crashes, check Windows Event Logs and compare working vs non-working builds (“Sesame Street technique”).
+
 # Relaying Bugs to the Development Team
 
 You may find that some features do not work as intended. Please either email the development team explaining your issue or go to [this link](https://github.com/oss-slu/SpeechTranscription/issues) where you can create a new "issue" and describe your problem. We are happy to help diagnose and resolve problems!

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@ python-docx
 git+https://github.com/openai/whisper.git
 sv_ttk
 #pattern
-git+https://github.com/clips/pattern.git
+git+https://github.com/clips/pattern.git #pattern is required for text processing; install from GitHub because PyPI version is outdated
 customtkinter
 pyannote.audio
 matplotlib
 numpy
 simple_diarizer
 python-dotenv
-lightning_fabric
+lightning_fabric # required for pyannote.audio / torch ecosystem
 pillow
 
 # For testing purposes


### PR DESCRIPTION
**This PR addresses the following CI/CD ticket: https://github.com/oss-slu/oss_cicd_automation/issues/1**

**What was investigated?**

- Checked Windows Event Logs for crash evidence. Initial Windows DCOM log entries (ContentDeliveryManager) were noise and unrelated.
- Reproduced the crash locally by running the packaged `.exe` from Command Prompt. That revealed Python runtime/DLL errors and file-not-found exceptions for package data files.
- Confirmed the app runs in a development environment with `python GUI.py` (so the crash is packaging and dependency-related).

**What was changed?**
1. Added comments to requirements.txt file, specifically for pattern and lightning fabric.
2. Created a section titled "Known Issues and Packaging Notes" in the README.md file describing why the .exe file crashes on a Windows machine

**What were the root causes behind the crash?**

1. Missing runtime data files in the packaged build: some third-party packages (notably `pattern` and `lightning_fabric`) rely on non-Python model/data files (e.g., `pattern/text/en/en-model.slp`, `lightning_fabric/version.info`) that PyInstaller does not bundle by default.
2. Mismatched build Python / missing DLLs: the `.exe` sometimes reported missing `python3x.dll` indicating the build environment and target runtime were not aligned.
3. Packages requiring compilation: `webrtcvad` failed to build without MS Visual C++ Build Tools.
4. FFmpeg missing: `pydub` emits a warning if `ffmpeg` is not on PATH (nonfatal but affects audio processing).

**Actions taken in Windows Command Prompt (reproducible steps)**

1. Created a clean Python 3.9 virtual environment (we used `venv39`) to ensure compatibility with `pattern`:
  
   python -m venv venv39
   venv39\Scripts\activate
   python -m pip install --upgrade pip

2. Installed dependencies by pip install -r requirements.txt. For pattern, we installed from GitHub because PyPI is outdated: pip install git+https://github.com/clips/pattern.git, and for Whisper and other heavy dependencies: pip install openai-whisper pyannote.audio. For packages requiring native build tools:  

pip install webrtcvad
If this fails, install Visual C++ Build Tools and retry:
https://visualstudio.microsoft.com/visual-cpp-build-tools/

3. Rebuilt the .exe using PyInstaller and explicitly bundled runtime data and resource folders. Example command (Windows):

pyinstaller --onefile --windowed GUI.py ^
  --add-data "images;images" ^
  --add-data "components;components" ^
  --add-data "venv39\\Lib\\site-packages\\pattern\\text;pattern/text" ^
  --add-data "venv39\\Lib\\site-packages\\lightning_fabric;lightning_fabric" ^
  --add-data "venv39\\Lib\\site-packages\\pyannote;pyannote" ^
  --add-data "venv39\\Lib\\site-packages\\torch;torch" ^
  --add-data "venv39\\Lib\\site-packages\\torchaudio;torchaudio

**Notes**:
On Windows use semicolon (;) in --add-data pairs (source;dest). On macOS/Linux use colon (:).
If PyInstaller errors on the backport typing package, uninstall it from the venv:

venv39\Scripts\python -m pip uninstall typing

4. Verified that python GUI.py runs in the venv, and dist\GUI.exe launches (tested locally). If still failing, check the Windows Event Viewer and run the .exe from a Command Prompt to capture printed errors.



