### PR TITLE
Add SLSA 3 Provenance

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,16 +1,16 @@
-on: 
-  push:
-    branches:
-      - main
-      - fix-mac-exe
-      - testingv4artifact
-      - issue169_dependency
-      - issue178_build-test-failures
+name: macOS Build Reusable
+
+on:
+  workflow_call:
+
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
 
 jobs:
   build-macos:
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -34,6 +34,9 @@ jobs:
       - run: pip uninstall -y typing
       - name: Build executable
         run: pyinstaller --name Saltify --windowed --noconfirm --onefile -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/Saltify
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,40 +7,35 @@ on:
       - main
 
 permissions:
-  id-token: write    # Required for provenance
+  attestations: write
   contents: write
+  id-token: write
   packages: read
   actions: read
 
 jobs:
   call-macos-build:
-    uses: oss-slu/SpeechTranscription/.github/workflows/macos-build.yml@build_fixes_copy
-
+    uses: ./.github/workflows/macos-build.yml
   call-windows-build:
-    uses: oss-slu/SpeechTranscription/.github/workflows/windows-build.yml@build_fixes_copy
-
+    uses: ./.github/workflows/windows-build.yml
   release:
     needs: [call-macos-build, call-windows-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Create artifacts directory
         run: mkdir -p artifacts/macos artifacts/windows
-
       - name: Download macOS build artifacts
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_macos
           path: artifacts/macos
-
       - name: Download Windows build artifacts
         uses: actions/download-artifact@v4
         with:
           name: SpeechTranscription_windows
           path: artifacts/windows
-
       - name: List directory structure
         run: |
           echo "Full directory structure:"
@@ -50,7 +45,6 @@ jobs:
           ls -la artifacts/
           ls -la artifacts/macos || echo "No macOS artifacts"
           ls -la artifacts/windows || echo "No Windows artifacts"
-
       - name: Create project ZIP
         run: |
           echo "Build number: ${{ github.run_number }}" >> release_notes.md
@@ -71,37 +65,25 @@ jobs:
             zip -j artifacts/Saltify_windows.zip artifacts/windows/*
           else
             echo "Note: Windows executable not available for this release" >> release_notes.md
+          fi
           
           echo "- Saltify_macos.zip: macOS executable" >> release_notes.md
           echo "- Saltify_windows.zip: Windows executable" >> release_notes.md
-
-      # 🔑 Generate SLSA Provenance for macOS artifact
-      - name: Generate SLSA Provenance for macOS
-        if: exists('artifacts/Saltify_macos.zip')
-        uses: slsa-framework/slsa-github-generator/actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v1
         with:
-          subject-path: "artifacts/Saltify_macos.zip"
-
-      # 🔑 Generate SLSA Provenance for Windows artifact
-      - name: Generate SLSA Provenance for Windows
-        if: exists('artifacts/Saltify_windows.zip')
-        uses: slsa-framework/slsa-github-generator/actions/attest-build-provenance@v1
-        with:
-          subject-path: "artifacts/Saltify_windows.zip"
-
+          subject-path: artifacts/Saltify_*.zip
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ github.run_number }}
-          release_name: Release ${{ github.run_number }}
+          name: Release ${{ github.run_number }}
           body_path: ./release_notes.md
           draft: false
           prerelease: false
-
-      - name: Upload macOS Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Release Assets
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,8 +92,7 @@ jobs:
           asset_path: artifacts/Saltify_macos.zip
           asset_name: Saltify_macos.zip
           asset_content_type: application/zip
-
-      - name: Upload Windows Release Asset
+      - name: Upload Release Assets
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,22 +1,21 @@
+name: Windows Build Reusable
+
 on:
-  push:
-    branches:
-      - main
-      - fix-exe
-      - testingv4artifact
-      - issue169_dependency
-      - issue178_build-test-failures
+  workflow_call:
+
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
 
 jobs:
   build-windows:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
-
       - name: Install Java
         shell: powershell
         run: |
@@ -26,27 +25,22 @@ jobs:
           } else {
             Write-Host "Java is already installed."
           }
-
       - name: Install Specific Python Version
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.7
-
       - name: Install NLTK
         run: |
           pip install nltk
           python -m nltk.downloader punkt
-      
       - name: Cache Python packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-
       - run: pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
       - run: pip uninstall -y typing
       - run: pyinstaller --name Saltify --windowed --noconfirm --onefile -c --copy-metadata torch --copy-metadata tqdm --copy-metadata regex --copy-metadata sacremoses --copy-metadata requests --copy-metadata packaging --copy-metadata filelock --copy-metadata numpy --copy-metadata tokenizers --copy-metadata importlib_metadata --collect-data sv_ttk --recursive-copy-metadata "openai-whisper" --collect-data whisper GUI.py
-
       - shell: cmd 
         run: |
           robocopy build_assets dist/Saltify /e /v 
@@ -54,7 +48,9 @@ jobs:
           robocopy dist/Saltify/_internal/lightning dist/Saltify/_internal/lightning_fabric /e /v
           mkdir dist\Saltify\_internal\pattern\text\en\
           move dist\Saltify\en-model.slp dist\Saltify\_internal\pattern\text\en\
-      
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/Saltify.exe
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
This PR updates the GitHub Actions release workflow to include [SLSA 3](https://slsa.dev/) compliance for the SpeechTranscription macOS and Windows artifacts.
- The workflow now generates verifiable provenance for both Saltify_macos.zip and Saltify_windows.zip release artifacts.
- Provenance ensures that any released binaries come directly from this repository, built via GitHub Actions, and cannot be tampered with.

**Changes**
- Added permissions.id-token: write to enable OIDC-based provenance signing.
- Added steps to generate SLSA provenance for both macOS and Windows ZIP files after they are created but before uploading to GitHub Release.
- Existing workflow continues to zip artifacts, create release notes, and publish the release.

**Why**
- Supply chain security is critical for open-source releases. By adopting SLSA 3:
- End-users and downstream projects can independently verify the authenticity of binaries.
- The build and release process becomes tamper-evident and traceable to the exact commit.