### PR TITLE
Issue#249

### DIFF
--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -481,7 +481,25 @@ class audioMenu(CTkFrame):
         self.progressCanvas.grid_remove()
         self.transcribeButton.configure(height=200)  # Reset button size
         self.transcribeButton.grid(row=2, column=0, rowspan=2, columnspan=2)
-    
+
+    def get_color_for_label(self, label):
+        """
+        Return the color hex for a label. label can be:
+         - "Speaker 1" / "Speaker 2"
+         - an alias like "C", "E", or a user-provided alias "Mom"
+        This centralizes color lookup and provides a safe fallback.
+        """
+        # direct match first
+        if label in SPEAKER_COLORS:
+            return SPEAKER_COLORS[label]
+
+        # if label is an alias, find which speaker it maps to and return that speaker color
+        for base_speaker, alias in self.speaker_aliases.items():
+            if alias == label:
+                return SPEAKER_COLORS.get(base_speaker, "#000000")
+
+        # fallback
+        return "#000000"
 
     @global_error_handler
     def labelSpeakers(self):
@@ -519,7 +537,7 @@ class audioMenu(CTkFrame):
         def apply_labels(speaker):
             current_text = self.getTranscriptionText()
             current_segments = current_text.split('\n')
-            color = SPEAKER_COLORS.get(speaker, "#FFFFFF")  # Get color for the speaker
+            color = self.get_color_for_label(speaker)
 
             for var, idx in self.segment_selections:
                 if var.get() and not current_segments[idx].startswith(f"{speaker}:"):

--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -483,12 +483,6 @@ class audioMenu(CTkFrame):
         self.transcribeButton.grid(row=2, column=0, rowspan=2, columnspan=2)
 
     def get_color_for_label(self, label):
-        """
-        Return the color hex for a label. label can be:
-         - "Speaker 1" / "Speaker 2"
-         - an alias like "C", "E", or a user-provided alias "Mom"
-        This centralizes color lookup and provides a safe fallback.
-        """
         # direct match first
         if label in SPEAKER_COLORS:
             return SPEAKER_COLORS[label]


### PR DESCRIPTION
Fixes #249 

**What was changed?**

In the Label Speaker dialog box, if the speaker has a Alias, the color's now match the corresponding color of the speaker. The colors of the corresponding Aliases are now represented in both the Transcription box as well as Label Speaker box.

**Why was it changed?**

Before, if a speaker had a Alias and some lines were assigned to that speaker, then the color would only show in the transcription box. But ideally, when labelling speaker, the users would want to know their previous assignment of labels. So, having color of the speaker in the Labelling box is important.

**How was it changed?**

In the applyLabels functions in labelSpeakers, it was assigning the color to be only white rather than the color of the speaker. So, added a new get-color_for_label function and now in applyLabel function, we get the color of the label instead of white color as default.

**Bug**

When we relabel the speaker, you can see in the After changes image, only the Speaker 2 color is reflected properly in the Transcription Box. For Speaker 1, only the Alias in the transcription box has the correct color, the text has the color of previous speaker.

Before Changes:
<img width="1440" height="900" alt="Screenshot 2025-09-15 at 3 55 18 PM" src="https://github.com/user-attachments/assets/ee3632cf-efd1-4c19-91fe-c377d4aafea2" />


After Changes:
<img width="1440" height="900" alt="Screenshot 2025-09-15 at 3 48 09 PM" src="https://github.com/user-attachments/assets/3f21d878-51dc-4609-b4a2-b752027c2753" />







