### PR TITLE
Resolving Inconsistent Color Coding in Speaker Labeling

### DIFF
--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -532,6 +532,14 @@ class audioMenu(CTkFrame):
             current_text = self.getTranscriptionText()
             current_segments = current_text.split('\n')
             color = self.get_color_for_label(speaker)
+            speaker1_alias = self.speaker_aliases.get("Speaker 1", "C")
+            speaker2_alias = self.speaker_aliases.get("Speaker 2", "E")
+            other = ""
+            if speaker == speaker1_alias:
+                other = speaker2_alias
+            else:
+                other = speaker1_alias
+
 
             for var, idx in self.segment_selections:
                 if var.get() and not current_segments[idx].startswith(f"{speaker}:"):
@@ -540,7 +548,13 @@ class audioMenu(CTkFrame):
                     if match:
                         timestamp = match.group(1)
                         rest = match.group(2)
-                        current_segments[idx] = f"[{timestamp}] {speaker}: {rest}"
+                        bracket = rest.find(']')
+
+                        #prevent previous speaker label from being maintained
+                        if rest[bracket + 1: bracket + 1 + len(other) + 1] == other + ":":
+                            current_segments[idx] = f"[{timestamp}] {speaker}: {rest[bracket + 3 + len(other):]}"
+                        elif rest[bracket + 1: bracket + 1 + len(speaker) + 1] != speaker + ":":
+                            current_segments[idx] = f"[{timestamp}] {speaker}: {rest}"
                     else:
                         current_segments[idx] = f"{speaker}: {line}"
                     var.set(0)


### PR DESCRIPTION
Fixes #257 #249 (Issue)

What was changed?

In the Label Speaker dialog box, if the speaker has a Alias, the color's now match the corresponding color of the speaker. The colors of the corresponding Aliases are now represented in both the Transcription box as well as Label Speaker box.

Why was it changed?

Before, if a speaker had a Alias and some lines were assigned to that speaker, then the color would only show in the transcription box. But ideally, when labelling speaker, the users would want to know their previous assignment of labels. So, having color of the speaker in the Labelling box is important.

How was it changed?

In the applyLabels functions in labelSpeakers, it was assigning the color to be only white rather than the color of the speaker. So, added a new get-color_for_label function and now in applyLabel function, we get the color of the label instead of white color as default.

Bug (Fixed)

When we relabel the speaker, you can see in the After changes image, only the Speaker 2 color is reflected properly in the Transcription Box. For Speaker 1, only the Alias in the transcription box has the correct color, the text has the color of previous speaker.

Before Changes:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/c84b3427-5d74-4c6d-a85c-8e4c9e22ae0f" />

After Changes:
<img width="1440" height="900" alt="Screenshot 2025-09-21 at 11 45 35 PM" src="https://github.com/user-attachments/assets/0684e282-a765-4f04-a1c2-d9c8434f1f16" />


