### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Use 'pip install -r requirements.txt' to install all requirements at once.
 
 pyaudio
-wave
+# wave
 nltk # (see Issue 55 https://github.com/oss-slu/SpeechTranscription/issues/55 for instructions on installing nltk - it is more than just 'pip install nltk')
 ffmpeg
 ffprobe


### PR DESCRIPTION
Removed `wave` from requirements.txt because it caused installation errors.

Error encountered earlier during PR merge:
  ERROR: Could not find a version that satisfies the requirement wave
  ERROR: No matching distribution found for wave

Reason:
- `wave` is a built-in Python standard library module, not a package on PyPI.
- Adding it to requirements.txt makes `pip install -r requirements.txt` fail.

Impact:
- Removing it fixes dependency installation in GitHub Actions.
- Application still works as expected, since `wave` can be imported directly without installing.


**What was changed?**
- Removed the `wave` entry from `requirements.txt`.
- No other code or functionality was modified.

**Why was it changed?**

- To resolve CI/CD build failures caused by `pip` trying (and failing) to install a non-existent `wave` package.
- Ensures the project’s dependencies reflect only installable third-party libraries.

**How was it changed?**

- Edited `requirements.txt` and deleted the `wave` line.
- Verified installation locally

