### PR TITLE
Fix #263 : Cross-Platform Packaging & Final Validation 

### DIFF
--- a/docs/Client_Installation_Guide_MacOS.md
+++ b/docs/Client_Installation_Guide_MacOS.md
@@ -1,0 +1,31 @@
+# Client's Guide for Installing and Running SpeechTranscription
+# System Requirements
+
+Before installing, ensure your system meets these requirements:
+* Operating System: macOS, Windows, or Linux
+* Python: Version 3.11.x
+* Java: Installed on your system [Download Here](https://www.oracle.com/java/technologies/downloads/)
+* MySQL: Installed and running [Download Here](https://dev.mysql.com/downloads/mysql/)
+
+# Installation Instructions
+* Download the latest release zip for your operating system from the GitHub Releases page:
+    * saltify_macos.zip for macOS
+    * saltify_windows.zip for Windows
+* Extract the zip file to a preferred location on your computer.
+
+# Setup for macOS
+* Open Terminal and navigate to the extracted folder: 
+    * cd /path/to/SpeechTranscription
+* Create and activate the Python virtual environment: 
+    * python3 -m venv venv
+    * source venv/bin/activate
+* Install dependencies: 
+    * pip install -r requirements.txt
+* For Mac users, the following libraries may need extra setup:
+    * brew install portaudio ffmpeg mysql pkg-config
+    * pip install pyaudio
+    * pip install mysql-connector-python
+* Run the program:
+    * python GUI.py
+
+

--- a/docs/Client_Installation_Guide_Windows.md
+++ b/docs/Client_Installation_Guide_Windows.md
@@ -1,0 +1,37 @@
+# Client's Guide for Installing and Running SpeechTranscription
+# System Requirements
+
+Before installing, ensure your system meets these requirements:
+* Operating System: macOS, Windows, or Linux
+* Python: Version 3.11.x
+* Java: Installed on your system [Download Here](https://www.oracle.com/java/technologies/downloads/)
+* MySQL: Installed and running [Download Here](https://dev.mysql.com/downloads/mysql/)
+
+# Installation Instructions
+* Download the latest release zip for your operating system from the GitHub Releases page:
+    * saltify_macos.zip for macOS
+    * saltify_windows.zip for Windows
+* Extract the zip file to a preferred location on your computer.
+
+# Setup for Windows/Linux
+* Open a Command Prompt (Windows) or Terminal (Linux) and navigate to the extracted folder:
+    * cd \path\to\SpeechTranscription
+* Install Python dependencies:
+    * pip install -r requirements.txt
+* Download the NLTK data:
+    * pip install nltk
+    * python -m nltk.downloader all
+* Run the program :
+    * python GUI.py
+
+# Running the Application
+* Double-check that the virtual environment is activated (macOS users).
+* Launch the application using:
+    * python GUI.py
+* The GUI should appear, and you can begin using the SpeechTranscription features immediately.
+
+# Notes for Clients
+* You do not need to modify environment variables—everything required for running the app is pre-packaged.
+* If you face issues with MySQL connection, make sure the MySQL server is running and accessible.
+* The application does not require Python installation if packaged with the executable (for releases).
+


### PR DESCRIPTION
Fixes #263 

**What was changed?**
I added installation guides for both platforms: Client_Installation_Guide_Windows.md/pdf and Client_Installation_Guide_MacOS.md/pdf. I also downloaded the saltify_windows.zip and saltify_macos.zip files from GitHub Releases to check what they include. These updates make sure the deliverables have clear documentation and can be tested on clean systems.

**Why was it changed?**
This change was needed to meet the requirement of giving platform-specific installation instructions in each release package. Without these guides, clients might have trouble setting up the application, which could cause failed installs. Checking the .zip files also makes sure the executables, assets, and configs are included as expected.

**How was it changed?**
I made and added installation guides for Windows and macOS, making sure they are part of the release files. Then, I downloaded the .zip files for both platforms and checked their contents against the project requirements. This confirmed that users on clean Windows and macOS systems can install and run Saltify without extra setup.

