### PR TITLE
270 fix macos GitHub release artifact

### DIFF
--- a/Client_Installation_Guide.md
+++ b/Client_Installation_Guide.md
@@ -4,7 +4,7 @@
 Before installing, ensure your system meets these requirements:
 * Java: Installed on your system [Download Here](https://www.oracle.com/java/technologies/downloads/)
 
-# Installation Instructions
+# Installation Instructions (For Both MacOs and Windows)
 * Download the latest release zip for your operating system from the GitHub Releases page (https://github.com/oss-slu/SpeechTranscription/releases):
     * saltify_macos.zip for macOS
     * saltify_windows.zip for Windows


### PR DESCRIPTION
Fixes #270 

**What was changed?**
The macOS build process in the GitHub Actions workflow (release.yml) was updated to match the local setup. Missing packaging steps and permission settings were added so the .app includes everything it needs to run on any Mac without extra setup. The final GitHub Release now has a complete, working, and signed macOS app.

**Why was it changed?**
This change was needed because the macOS version downloaded from GitHub didn’t open before, even though it worked fine when built locally. The problem came from missing files, permission issues, or setup differences in PyInstaller. The update fixes these issues so users can download and run the macOS app easily without any extra steps or errors.

**How was it changed?**
The team compared the local and GitHub build logs to find differences, fixed missing steps in release.yml, and made sure all needed files were included. They also corrected file permissions during the build process and tested the final .app on a clean Mac to confirm it worked properly. Once everything was verified, the working app was automatically uploaded through the CI/CD pipeline.

