### PR TITLE
added platform check for ffmpeg install

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,6 +49,7 @@ jobs:
         shell: cmd
         run: |
           pyinstaller --name Saltify ^
+          --windowed ^
           --noconfirm ^
           --onefile ^
           --add-data "images;images" ^


### PR DESCRIPTION
Fixes #issue_number

**What was changed?**

a check was added to the ffmpeg install

**Why was it changed?**

to ensure winget commands are only ran windows systems.

**How was it changed?**

Before ffmpeg is searched for and installed, platorm.system() is called to make sure it is on a windows system only, as those commands rely on windows based cmd calls
