### PR TITLE
Fix SALT annotation loss after Submit

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -15,6 +15,7 @@ on:
       - excellenceGUI
       - nltkDownloads
       - feature/remove-java-prerequisite_windows
+      - fix/salt-submit-annotation
 
 jobs:
   build-windows:

--- a/components/audio_menu.py
+++ b/components/audio_menu.py
@@ -820,11 +820,13 @@ class audioMenu(CTkFrame):
     @global_error_handler
     def applyCorrection(self):
         unlockItem(self.conventionBox)
-        correctedSentence = self.correctionEntryBox.get("1.0", "end")
+        correctedSentence = self.correctionEntryBox.get("1.0", "end").strip()
+
         timestart = correctedSentence.index("[")
         timeend = correctedSentence.index("]")
         timestamp = correctedSentence[timestart:timeend+1]
-        correctedSentence = timestamp + " " + addConventions.removeErrorCoding(correctedSentence[timeend+1:]) + "\n"
+        sentence_body = correctedSentence[timeend+1:].strip()
+        correctedSentence = f"{timestamp} {sentence_body}\n"
         self.conventionBox.insert("end", correctedSentence)
         self.correctionEntryBox.delete("1.0", "end")
         self.manageGrammarCorrection()


### PR DESCRIPTION
**Issue**
During client testing, it was observed that SALT annotation (e.g., /*3s) is correctly generated during Grammar Check, but disappears after clicking Submit. As a result, Add Morphemes later treats the word as correct (e.g., /3s), producing incorrect linguistic output.

**What was changed**
Updated the Submit functionality in audio_menu.py to preserve SALT annotations (e.g., /*3s) when inserting corrected sentences into the Convention Box.

**Why it was changed**
During client testing, it was observed that SALT annotations like /*3s were correctly generated during Grammar Check but disappeared after clicking Submit. This caused Add Morphemes to treat the word as correct (e.g., /3s), resulting in incorrect linguistic output.

**How it was changed**
Removed the use of removeErrorCoding() in the applyCorrection() function. Instead of cleaning the sentence, the corrected sentence is now inserted directly into the Convention Box while preserving the original SALT annotations.alities.