### PR TITLE
Bundle Java runtime for macOS build

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -11,10 +11,11 @@ on:
       - issue178_build-test-failures
       - issue-2-cicd-logging
       - macOS-testRelease
+      - feature/remove-java-prerequisite_macos
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +41,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
           pip install mysql-connector-python pyaudio
-        # python -m nltk.downloader punkt averaged_perceptron_tagger stopwords vader_lexicon
 
       - name: Initialize Git submodules
         run: git submodule update --init --recursive
@@ -48,7 +48,15 @@ jobs:
       - name: Remove obsolete typing package
         run: pip uninstall -y typing || echo "typing not installed"
 
-      # ✅ NEW: build-time NLTK download
+      - name: Download Temurin JDK 17 for macOS
+        run: |
+          curl -L -o temurin17.tar.gz "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_mac_hotspot_17.0.12_7.tar.gz"
+          tar -xzf temurin17.tar.gz
+          JDK_FOLDER=$(find . -maxdepth 1 -type d -name "jdk-17*" | head -n 1)
+          mv "$JDK_FOLDER" jre
+          chmod +x jre/Contents/Home/bin/java
+          ./jre/Contents/Home/bin/java -version
+
       - name: Download NLTK corpora for bundling
         run: |
           mkdir -p nltk_data
@@ -56,10 +64,8 @@ jobs:
           import nltk, os
           download_dir = "nltk_data"
           os.makedirs(download_dir, exist_ok=True)
-          # the ones that kept failing on client mac
           nltk.download("wordnet", download_dir=download_dir)
           nltk.download("omw-1.4", download_dir=download_dir)
-          # these two names fix your developer's odd names
           nltk.download("punkt", download_dir=download_dir)
           nltk.download("averaged_perceptron_tagger", download_dir=download_dir)
           PYCODE
@@ -71,6 +77,7 @@ jobs:
           --noconfirm \
           --onefile \
           --add-data "images:images" \
+          --add-data "jre:jre" \
           --add-data "build_assets/en-model.slp:pattern/text/en" \
           --add-data "CTkXYFrame:CTkXYFrame" \
           --add-data "nltk_data:nltk_data" \
@@ -109,6 +116,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         if: always()
-        with: 
+        with:
           name: SpeechTranscription_macos
-          path: dist/Saltify
+          path: dist/Saltify*

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/java_runtime.py
+++ b/java_runtime.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import platform
 
 def get_base_path():
     if getattr(sys, "frozen", False):
@@ -9,21 +10,40 @@ def get_base_path():
 
 def configure_bundled_java():
     base_path = get_base_path()
+    app_path = os.path.dirname(sys.executable)
+    system = platform.system()
 
-    possible_java_paths = [
-        os.path.join(base_path, "jre", "bin", "java.exe"),
-        os.path.join(os.path.dirname(sys.executable), "jre", "bin", "java.exe"),
-    ]
+    if system == "Windows":
+        possible_java_paths = [
+            os.path.join(base_path, "jre", "bin", "java.exe"),
+            os.path.join(app_path, "jre", "bin", "java.exe"),
+        ]
+
+    elif system == "Darwin":  # macOS
+        possible_java_paths = [
+            os.path.join(base_path, "jre", "Contents", "Home", "bin", "java"),
+            os.path.join(app_path, "jre", "Contents", "Home", "bin", "java"),
+            os.path.join(app_path, "..", "Resources", "jre", "Contents", "Home", "bin", "java"),
+        ]
+
+    else:
+        possible_java_paths = [
+            os.path.join(base_path, "jre", "bin", "java"),
+            os.path.join(app_path, "jre", "bin", "java"),
+        ]
 
     print("sys.frozen:", getattr(sys, "frozen", False))
     print("sys._MEIPASS:", getattr(sys, "_MEIPASS", "NOT SET"))
     print("sys.executable:", sys.executable)
+    print("System:", system)
 
     for java_exe in possible_java_paths:
+        java_exe = os.path.abspath(java_exe)
         print("Looking for Java at:", java_exe)
 
         if os.path.exists(java_exe):
             java_home = os.path.dirname(os.path.dirname(java_exe))
+
             os.environ["JAVA_HOME"] = java_home
             os.environ["PATH"] = os.path.join(java_home, "bin") + os.pathsep + os.environ.get("PATH", "")
 


### PR DESCRIPTION
What was changed?
Added bundled Java (JRE) support for macOS and updated java_runtime.py to work across Windows and macOS.

Why was it changed?
To remove the need for users to manually install Java and fix macOS runtime errors.

How was it changed?
Downloaded Temurin JDK in GitHub Actions, packaged it using PyInstaller (--add-data "jre:jre"), and added macOS Java path handling (jre/Contents/Home/bin/java).